### PR TITLE
Update qubits.py to make it work

### DIFF
--- a/pytket_cirq/pytket/cirq/qubits.py
+++ b/pytket_cirq/pytket/cirq/qubits.py
@@ -70,7 +70,7 @@ def xmon_to_arc(xmon: XmonDevice) -> Architecture:
         forward_neighbours = filter(lambda x: indexed_qubits.index(x)>indexed_qubits.index(qb), neighbours)
         for x in forward_neighbours:
             pairs.append((indexed_qubits.index(qb), indexed_qubits.index(x)))
-    return Architecture(pairs, nodes)
+    return Architecture(pairs)
 
 def _indexed_qubits_from_circuit(circuit : cirq.Circuit) -> List[Qid]:
     qubit_list = list(circuit.all_qubits())


### PR DESCRIPTION
I tried to use `pytket` with `cirq` and got error message 
```
return Architecture(pairs, nodes)
TypeError: __init__(): incompatible constructor arguments. The following argument types are supported:
    1. pytket._routing.Architecture(connections: List[Tuple[int, int]])
```
I was unable to find out the exact constructor of your `Architecture`, because that part is not open source I believe? However, from the message, it seems that the `nodes` which is an integer meaning how many qubits there are, is redundant. So I deleted it and changed the corresponding line in `qubits.py` to `return Architecture(pairs)` and then it worked.
