### PR TITLE
Update README.md in examples folder

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@ Here you can find notebooks showing features and example usage of pytket.
 
 *Note: When viewing our examples, github has a bug where it occasionally can't render Jupyter notebooks properly. To bypass this, you can either clone the repo and open the examples in Jupyter yourself (this is recommended! You can play around with them), or you can enter the corresponding URL into https://nbviewer.jupyter.org and view examples there.*
 
-[backends_example](https://github.com/CQCL/pytket/blob/master/examples/backends_example.ipynb) - Running circuits on our allowed backends
+[backends_example](https://github.com/CQCL/pytket/blob/master/examples/backends_example.ipynb) - Running circuits on our allowed backends.
 
 [circuit_generation_example](https://github.com/CQCL/pytket/blob/master/examples/circuit_generation_example.ipynb) - Advance methods for circuit generation in pytket.
 
@@ -15,8 +15,6 @@ Here you can find notebooks showing features and example usage of pytket.
 [expectation_value_example](https://github.com/CQCL/pytket/blob/master/examples/expectation_value_example.ipynb) - Calculating expectation values of Hamiltonian operators using pytket.
 
 [Forest_portability_example](https://github.com/CQCL/pytket/blob/master/examples/Forest_portability_example.ipynb) - Porting code between different quantum software development platforms using pytket.
-
-[pyquil_example](https://github.com/CQCL/pytket/blob/master/examples/cirq_routing_example.ipynb) - PyQuil interface and leveraging features across platforms.
 
 [routing_example](https://github.com/CQCL/pytket/blob/master/examples/routing_example.ipynb) - Mapping quantum circuits to quantum devices. Includes placement and routing.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,11 +4,11 @@ Here you can find notebooks showing features and example usage of pytket.
 
 *Note: When viewing our examples, github has a bug where it occasionally can't render Jupyter notebooks properly. To bypass this, you can either clone the repo and open the examples in Jupyter yourself (this is recommended! You can play around with them), or you can enter the corresponding URL into https://nbviewer.jupyter.org and view examples there.*
 
-[backends_example](https://github.com/CQCL/pytket/blob/master/examples/backends_example.ipynb) - Running circuits on our allowed backends.
+[backends_example](https://github.com/CQCL/pytket/blob/master/examples/backends_example.ipynb) - Running circuits on some of our backends.
 
-[circuit_generation_example](https://github.com/CQCL/pytket/blob/master/examples/circuit_generation_example.ipynb) - Advance methods for circuit generation in pytket.
+[circuit_generation_example](https://github.com/CQCL/pytket/blob/master/examples/circuit_generation_example.ipynb) - Advanced methods for circuit generation in pytket.
 
-[circuit_analysis_example](https://github.com/CQCL/pytket/blob/master/examples/circuit_analysis_example.ipynb) - Methods for visualizing and anaylsing circuits in pytket.
+[circuit_analysis_example](https://github.com/CQCL/pytket/blob/master/examples/circuit_analysis_example.ipynb) - Methods for visualising and analysing circuits in pytket.
 
 [compilation_example](https://github.com/CQCL/pytket/blob/master/examples/compilation_example.ipynb) - Introduction to basic compilation passes available in pytket and how to combine them.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,15 +4,22 @@ Here you can find notebooks showing features and example usage of pytket.
 
 *Note: When viewing our examples, github has a bug where it occasionally can't render Jupyter notebooks properly. To bypass this, you can either clone the repo and open the examples in Jupyter yourself (this is recommended! You can play around with them), or you can enter the corresponding URL into https://nbviewer.jupyter.org and view examples there.*
 
-[cirq_routing_example](https://github.com/CQCL/pytket/blob/master/examples/cirq_routing_example.ipynb) - Cirq interface and routing.
+[backends_example](https://github.com/CQCL/pytket/blob/master/examples/backends_example.ipynb) - Running circuits on our allowed backends
 
+[circuit_generation_example](https://github.com/CQCL/pytket/blob/master/examples/circuit_generation_example.ipynb) - Advance methods for circuit generation in pytket.
+
+[circuit_analysis_example](https://github.com/CQCL/pytket/blob/master/examples/circuit_analysis_example.ipynb) - Methods for visualizing and anaylsing circuits in pytket.
+
+[compilation_example](https://github.com/CQCL/pytket/blob/master/examples/compilation_example.ipynb) - Introduction to basic compilation passes available in pytket and how to combine them.
+
+[expectation_value_example](https://github.com/CQCL/pytket/blob/master/examples/expectation_value_example.ipynb) - Calculating expectation values of Hamiltonian operators using pytket.
+
+[Forest_portability_example](https://github.com/CQCL/pytket/blob/master/examples/Forest_portability_example.ipynb) - Porting code between different quantum software development platforms using pytket.
 
 [pyquil_example](https://github.com/CQCL/pytket/blob/master/examples/cirq_routing_example.ipynb) - PyQuil interface and leveraging features across platforms.
+
+[routing_example](https://github.com/CQCL/pytket/blob/master/examples/routing_example.ipynb) - Mapping quantum circuits to quantum devices. Includes placement and routing.
 
 [symbolics_example](https://github.com/CQCL/pytket/blob/master/examples/symbolics_example.ipynb) - Constructing and using circuits with symbolic parameters.
 
 [tket_benchmarking](https://github.com/CQCL/pytket/blob/master/examples/tket_benchmarking.ipynb) - Run IBM benchmark circuits, from [arxiv:1902:08091](https://arxiv.org/abs/1902.08091).
-
-[transform_example](https://github.com/CQCL/pytket/blob/master/examples/transform_example.ipynb) - Transform and circuit optimisation interface, along with examples of conversion to and from each framework. 
-
-[backends_example](https://github.com/CQCL/pytket/blob/master/examples/backends_example.ipynb) - Running circuits on our allowed backends


### PR DESCRIPTION
This README.md file is missing links to new example notebooks and has outdated links to previous example notebooks.