### PR TITLE
Check out repo before running changes filter.

### DIFF
--- a/.github/workflows/check-examples.yml
+++ b/.github/workflows/check-examples.yml
@@ -15,6 +15,7 @@ jobs:
     outputs:
       examples: ${{ steps.filter.outputs.examples }}
     steps:
+    - uses: actions/checkout@v2
     - uses: dorny/paths-filter@v2
       id: filter
       with:

--- a/.github/workflows/check-manual.yml
+++ b/.github/workflows/check-manual.yml
@@ -15,6 +15,7 @@ jobs:
     outputs:
       manual: ${{ steps.filter.outputs.manual }}
     steps:
+    - uses: actions/checkout@v2
     - uses: dorny/paths-filter@v2
       id: filter
       with:


### PR DESCRIPTION
The weekly scheduled runs were always failing because we hadn't checked out the repo. (I guess this is automatic for pull requests.)