### PR TITLE
Specify base branch for CI checks.

### DIFF
--- a/.github/workflows/check-examples.yml
+++ b/.github/workflows/check-examples.yml
@@ -19,6 +19,7 @@ jobs:
     - uses: dorny/paths-filter@v2
       id: filter
       with:
+        base: ${{ github.ref }}
         filters: |
           examples:
             - 'examples/**'

--- a/.github/workflows/check-manual.yml
+++ b/.github/workflows/check-manual.yml
@@ -19,6 +19,7 @@ jobs:
     - uses: dorny/paths-filter@v2
       id: filter
       with:
+        base: ${{ github.ref }}
         filters: |
           manual:
             - 'manual/**'


### PR DESCRIPTION
Otherwise these scripts fail with an error on the scheduled build because they don't find the default branch (not sure why).