### PR TITLE
[docs] Fixed `build-manual` for MacOS

### DIFF
--- a/build-manual
+++ b/build-manual
@@ -6,7 +6,8 @@ python -m pip install --pre git+git://github.com/willsimmons1465/jupyter-sphinx.
 
 cd manual/
 
-sed "s/REQUIREMENTS/$(sed -e 's/[\&/]/\\&/g' -e 's/$/\\n/' ../requirements.txt | tr -d '\n')/" index-rst-template > index.rst
+ESCAPED_REQS=$(awk '{printf "%s%s",sep,$0; sep="\\\n"} END{print ""}' ../requirements.txt)
+sed "s/REQUIREMENTS/$ESCAPED_REQS/" index-rst-template > index.rst
 
 rm -rf build/
 sphinx-build -b html . build


### PR DESCRIPTION
I'm solving an issue that appeared on some non-Linux systems, due to the non-standard usage of `\n` in `sed`. (see comments in https://unix.stackexchange.com/a/13716). 

I haven't found a readable cross-platform solution with `sed` so I switched to `awk` instead, hoping that works for everyone.