### PR TITLE
[TKET-1660] Add a link to pytket documentation website.

### DIFF
--- a/manual/index-rst-template
+++ b/manual/index-rst-template
@@ -17,6 +17,12 @@ REQUIREMENTS
     manual_noise.rst
     manual_assertion.rst
 
+.. toctree::
+	:caption: More documentation:
+	:maxdepth: 1
+
+	pytket <https://cqcl.github.io/tket/pytket/api/index.html>
+
 Indices and Tables
 ==================
 


### PR DESCRIPTION
Fixes [TKET-1660](https://cqc.atlassian.net/browse/TKET-1660?atlOrigin=eyJpIjoiNGU3NDQwZDBiZDNiNGNkZjg4ZTUyZTc0NGExZGZkOGUiLCJwIjoiaiJ9).

This PR addresses adding a link to the main `pytket` documentation website in the side bar of the manual in the same fashion as the `pytket-extensions` [website](https://cqcl.github.io/pytket-extensions/api/index.html).