### PR TITLE
Custom passdocs

### DIFF
--- a/docs/manual/manual_compiler.html
+++ b/docs/manual/manual_compiler.html
@@ -952,7 +952,7 @@ The <code class="xref py py-class docutils literal notranslate"><span class="pre
     <span class="n">circ_prime</span> <span class="o">=</span> <span class="n">Circuit</span><span class="p">(</span><span class="n">n_qubits</span><span class="p">)</span> <span class="c1"># Define a replacement circuit</span>
 
     <span class="k">for</span> <span class="n">cmd</span> <span class="ow">in</span> <span class="n">circ</span><span class="o">.</span><span class="n">get_commands</span><span class="p">():</span>
-        <span class="n">qubit_list</span> <span class="o">=</span> <span class="n">cmd</span><span class="o">.</span><span class="n">qubits</span> <span class="c1"># Qubit our gate is applied on (as a list)</span>
+        <span class="n">qubit_list</span> <span class="o">=</span> <span class="n">cmd</span><span class="o">.</span><span class="n">qubits</span> <span class="c1"># Qubit(s) our gate is applied on (as a list)</span>
         <span class="k">if</span> <span class="n">cmd</span><span class="o">.</span><span class="n">op</span><span class="o">.</span><span class="n">type</span> <span class="o">==</span> <span class="n">OpType</span><span class="o">.</span><span class="n">Z</span><span class="p">:</span> <span class="c1"># If cmd is a Z gate, decompose to a H, X, H sequence.</span>
             <span class="n">circ_prime</span><span class="o">.</span><span class="n">add_gate</span><span class="p">(</span><span class="n">OpType</span><span class="o">.</span><span class="n">H</span><span class="p">,</span> <span class="n">qubit_list</span><span class="p">)</span>
             <span class="n">circ_prime</span><span class="o">.</span><span class="n">add_gate</span><span class="p">(</span><span class="n">OpType</span><span class="o">.</span><span class="n">X</span><span class="p">,</span> <span class="n">qubit_list</span><span class="p">)</span>
@@ -1318,15 +1318,15 @@ the main circuit and the postprocessing circuit, returning both.</p>
 </div>
 </div>
 <div class="cell_output docutils container">
-<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>[[0 0]
- [1 1]
- [0 0]
- [1 1]
+<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>[[1 1]
  [1 1]
  [0 0]
  [0 0]
  [0 0]
+ [1 1]
+ [1 1]
  [0 0]
+ [1 1]
  [0 0]]
 </pre></div>
 </div>

--- a/docs/manual/manual_compiler.html
+++ b/docs/manual/manual_compiler.html
@@ -942,12 +942,10 @@ CXs 3
 <h3>User-defined Passes<a class="headerlink" href="#user-defined-passes" title="Permalink to this heading"></a></h3>
 <p>We have already seen that pytket allows users to combine passes in a desired order using <code class="xref py py-class docutils literal notranslate"><span class="pre">SequencePass</span></code>. An addtional feature is the <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> which allows users to define their own custom circuit transformation using pytket.
 The <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> class accepts a <code class="docutils literal notranslate"><span class="pre">transform</span></code> parameter, a python function that takes a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> as input and returns a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> as output.</p>
-<p>We will show how to use <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> by defining a simple tranfromation that replaces any Pauli Z gate in the <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> with a Hadamard gate, Pauli X gate, Hadamard gate chain.</p>
-<p>After we’ve defined our <code class="docutils literal notranslate"><span class="pre">transfrom</span></code> we can construct a <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code>. This pass can then be applied to a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code>.</p>
+<p>We will show how to use <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> by defining a simple transformation that replaces any Pauli Z gate in the <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> with a Hadamard gate, Pauli X gate, Hadamard gate chain.</p>
 <div class="jupyter_cell jupyter_container docutils container">
 <div class="cell_input code_cell docutils container">
 <div class="highlight-ipython3 notranslate"><div class="highlight"><pre><span></span><span class="kn">from</span> <span class="nn">pytket</span> <span class="kn">import</span> <span class="n">Circuit</span><span class="p">,</span> <span class="n">OpType</span>
-<span class="kn">from</span> <span class="nn">pytket.passes</span> <span class="kn">import</span> <span class="n">CustomPass</span>
 
 <span class="k">def</span> <span class="nf">z_transform</span><span class="p">(</span><span class="n">circ</span><span class="p">):</span>
     <span class="n">n_qubits</span> <span class="o">=</span> <span class="n">circ</span><span class="o">.</span><span class="n">n_qubits</span>
@@ -963,6 +961,16 @@ The <code class="xref py py-class docutils literal notranslate"><span class="pre
             <span class="n">circ_prime</span><span class="o">.</span><span class="n">add_gate</span><span class="p">(</span><span class="n">cmd</span><span class="o">.</span><span class="n">op</span><span class="o">.</span><span class="n">type</span><span class="p">,</span> <span class="n">cmd</span><span class="o">.</span><span class="n">op</span><span class="o">.</span><span class="n">params</span><span class="p">,</span> <span class="n">qubit_list</span><span class="p">)</span> <span class="c1"># Otherwise, apply the gate as usual.</span>
 
     <span class="k">return</span> <span class="n">circ_prime</span>
+</pre></div>
+</div>
+</div>
+<div class="cell_output docutils container">
+</div>
+</div>
+<p>After we’ve defined our <code class="docutils literal notranslate"><span class="pre">transform</span></code> we can construct a <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code>. This pass can then be applied to a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code>.</p>
+<div class="jupyter_cell jupyter_container docutils container">
+<div class="cell_input code_cell docutils container">
+<div class="highlight-ipython3 notranslate"><div class="highlight"><pre><span></span><span class="kn">from</span> <span class="nn">pytket.passes</span> <span class="kn">import</span> <span class="n">CustomPass</span>
 
 <span class="n">DecompseZPass</span> <span class="o">=</span> <span class="n">CustomPass</span><span class="p">(</span><span class="n">z_transform</span><span class="p">)</span> <span class="c1"># Define our pass</span>
 
@@ -995,6 +1003,7 @@ The <code class="xref py py-class docutils literal notranslate"><span class="pre
 </div>
 </div>
 </div>
+<p>We see from the output above that our newly defined <code class="xref py py-class docutils literal notranslate"><span class="pre">DecompseZPass</span></code> has successfully decomposed the Pauli Z gates to Hadamard, Pauli X, Hadamard chains and left other gates unchanged.</p>
 <div class="admonition warning">
 <p class="admonition-title">Warning</p>
 <p>pytket does not require that <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> preserves the unitary of the <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> . This is for the user to ensure.</p>
@@ -1310,15 +1319,15 @@ the main circuit and the postprocessing circuit, returning both.</p>
 </div>
 <div class="cell_output docutils container">
 <div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>[[1 1]
+ [1 1]
+ [1 1]
  [0 0]
  [0 0]
  [1 1]
+ [1 1]
  [0 0]
- [1 1]
- [1 1]
- [1 1]
- [1 1]
- [0 0]]
+ [0 0]
+ [1 1]]
 </pre></div>
 </div>
 </div>

--- a/docs/manual/manual_compiler.html
+++ b/docs/manual/manual_compiler.html
@@ -942,7 +942,7 @@ CXs 3
 <h3>User-defined Passes<a class="headerlink" href="#user-defined-passes" title="Permalink to this heading"></a></h3>
 <p>We have already seen that pytket allows users to combine passes in a desired order using <code class="xref py py-class docutils literal notranslate"><span class="pre">SequencePass</span></code>. An addtional feature is the <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> which allows users to define their own custom circuit transformation using pytket.
 The <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> class accepts a <code class="docutils literal notranslate"><span class="pre">transform</span></code> parameter, a python function that takes a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> as input and returns a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> as output.</p>
-<p>We will show how to use the <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> with a simple tranfromation that replaces any Pauli Z gate in the <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> with a Hadamard gate, Pauli X gate, Hadamard gate chain.</p>
+<p>We will show how to use <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> by defining a simple tranfromation that replaces any Pauli Z gate in the <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> with a Hadamard gate, Pauli X gate, Hadamard gate chain.</p>
 <p>After we’ve defined our <code class="docutils literal notranslate"><span class="pre">transfrom</span></code> we can construct a <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code>. This pass can then be applied to a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code>.</p>
 <div class="jupyter_cell jupyter_container docutils container">
 <div class="cell_input code_cell docutils container">
@@ -997,7 +997,7 @@ The <code class="xref py py-class docutils literal notranslate"><span class="pre
 </div>
 <div class="admonition warning">
 <p class="admonition-title">Warning</p>
-<p>pytket does not require that <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> preserves the unitary of the <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> .</p>
+<p>pytket does not require that <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> preserves the unitary of the <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> . This is for the user to ensure.</p>
 </div>
 </section>
 <section id="partial-compilation">
@@ -1310,15 +1310,15 @@ the main circuit and the postprocessing circuit, returning both.</p>
 </div>
 <div class="cell_output docutils container">
 <div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>[[1 1]
+ [0 0]
+ [0 0]
  [1 1]
  [0 0]
- [0 0]
- [0 0]
  [1 1]
- [0 0]
- [0 0]
- [0 0]
- [1 1]]
+ [1 1]
+ [1 1]
+ [1 1]
+ [0 0]]
 </pre></div>
 </div>
 </div>

--- a/docs/manual/manual_compiler.html
+++ b/docs/manual/manual_compiler.html
@@ -61,6 +61,7 @@
 <li class="toctree-l2"><a class="reference internal" href="#initial-and-final-maps">Initial and Final Maps</a></li>
 <li class="toctree-l2"><a class="reference internal" href="#advanced-topics">Advanced Topics</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="#compiling-symbolic-circuits">Compiling Symbolic Circuits</a></li>
+<li class="toctree-l3"><a class="reference internal" href="#customised-passes">Customised Passes</a></li>
 <li class="toctree-l3"><a class="reference internal" href="#partial-compilation">Partial Compilation</a></li>
 <li class="toctree-l3"><a class="reference internal" href="#measurement-reduction">Measurement Reduction</a></li>
 <li class="toctree-l3"><a class="reference internal" href="#contextual-optimisations">Contextual Optimisations</a><ul>
@@ -573,7 +574,7 @@ True
 </div>
 <div class="cell_output docutils container">
 <div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>[CZ q[0], q[1];, Ry(3.88883) q[0];, Rx(3.2547) q[0];, Ry(3.56808) q[0];, CX q[1], q[0];]
-[CX q[0], q[1];, TK1(0, 2.5, 2) q[2];, TK1(3.89281, 0.5, 1) q[1];, CX q[1], q[2];, TK1(0, 1.425, 3.5) q[1];, TK1(0, 1.5, 1.94) q[2];, CX q[1], q[2];, TK1(1, 0.5, 0.187194) q[1];, TK1(0, 0, 2.5) q[2];, CX q[1], q[0];]
+[CX q[0], q[1];, TK1(0, 0.5, 2) q[2];, TK1(3.89281, 0.5, 1) q[1];, CX q[1], q[2];, TK1(0, 1.425, 3.5) q[1];, TK1(0, 1.5, 1.94) q[2];, CX q[1], q[2];, TK1(1, 0.5, 0.187194) q[1];, TK1(0, 0, 2.5) q[2];, CX q[1], q[0];]
 </pre></div>
 </div>
 </div>
@@ -926,7 +927,7 @@ CXs 3
 </div>
 </div>
 <div class="cell_output docutils container">
-<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>(0.7499999999999999+0j)
+<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>(0.75+0j)
 (1.5+0j)
 </pre></div>
 </div>
@@ -935,6 +936,70 @@ CXs 3
 <div class="admonition note">
 <p class="admonition-title">Note</p>
 <p>Every <code class="xref py py-class docutils literal notranslate"><span class="pre">Backend</span></code> requires <code class="xref py py-class docutils literal notranslate"><span class="pre">NoSymbolsPredicate</span></code>, so it is necessary to instantiate all symbols before running a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code>.</p>
+</div>
+</section>
+<section id="customised-passes">
+<h3>Customised Passes<a class="headerlink" href="#customised-passes" title="Permalink to this heading"></a></h3>
+<p>We have already seen that pytket allows users to combine passes in a desired order using <code class="xref py py-class docutils literal notranslate"><span class="pre">SequencePass</span></code>. An addtional feature is the <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> allowing users to define their own customised circuit transformation using pytket.
+The <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> class accepts a <cite>transform</cite> parameter.This <cite>transform</cite> is a python function that takes a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> as input and returns a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> as output.</p>
+<p>We will illustrate this using a function which simply replaces Pauli Z gates with a Pauli X and two Hadamard gates.</p>
+<p>We can now define our <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> using this function and apply it to a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> in the usual way.</p>
+<div class="jupyter_cell jupyter_container docutils container">
+<div class="cell_input code_cell docutils container">
+<div class="highlight-ipython3 notranslate"><div class="highlight"><pre><span></span><span class="kn">from</span> <span class="nn">pytket</span> <span class="kn">import</span> <span class="n">Circuit</span><span class="p">,</span> <span class="n">OpType</span>
+<span class="kn">from</span> <span class="nn">pytket.passes</span> <span class="kn">import</span> <span class="n">CustomPass</span>
+
+<span class="k">def</span> <span class="nf">z_transform</span><span class="p">(</span><span class="n">circ</span><span class="p">):</span>
+    <span class="n">n_qubits</span> <span class="o">=</span> <span class="n">circ</span><span class="o">.</span><span class="n">n_qubits</span>
+    <span class="n">circ_prime</span> <span class="o">=</span> <span class="n">Circuit</span><span class="p">(</span><span class="n">n_qubits</span><span class="p">)</span> <span class="c1"># Define a replacement circuit</span>
+
+    <span class="k">for</span> <span class="n">cmd</span> <span class="ow">in</span> <span class="n">circ</span><span class="o">.</span><span class="n">get_commands</span><span class="p">():</span> <span class="c1"># Iterate through all the gates in our input Circuit</span>
+        <span class="n">qubit_list</span> <span class="o">=</span> <span class="n">cmd</span><span class="o">.</span><span class="n">qubits</span> <span class="c1"># Qubit our gate is applied on (as a list)</span>
+        <span class="k">if</span> <span class="n">cmd</span><span class="o">.</span><span class="n">op</span><span class="o">.</span><span class="n">type</span> <span class="o">==</span> <span class="n">OpType</span><span class="o">.</span><span class="n">Z</span><span class="p">:</span> <span class="c1"># If cmd is a Z gate, decompose to a H, X, H sequence.</span>
+            <span class="n">circ_prime</span><span class="o">.</span><span class="n">add_gate</span><span class="p">(</span><span class="n">OpType</span><span class="o">.</span><span class="n">H</span><span class="p">,</span> <span class="n">qubit_list</span><span class="p">)</span>
+            <span class="n">circ_prime</span><span class="o">.</span><span class="n">add_gate</span><span class="p">(</span><span class="n">OpType</span><span class="o">.</span><span class="n">X</span><span class="p">,</span> <span class="n">qubit_list</span><span class="p">)</span>
+            <span class="n">circ_prime</span><span class="o">.</span><span class="n">add_gate</span><span class="p">(</span><span class="n">OpType</span><span class="o">.</span><span class="n">H</span><span class="p">,</span> <span class="n">qubit_list</span><span class="p">)</span>
+        <span class="k">else</span><span class="p">:</span>
+            <span class="c1"># Otherwise apply the gate as usual</span>
+            <span class="n">params</span> <span class="o">=</span> <span class="n">cmd</span><span class="o">.</span><span class="n">op</span><span class="o">.</span><span class="n">params</span>
+            <span class="n">circ_prime</span><span class="o">.</span><span class="n">add_gate</span><span class="p">(</span><span class="n">cmd</span><span class="o">.</span><span class="n">op</span><span class="o">.</span><span class="n">type</span><span class="p">,</span> <span class="n">params</span><span class="p">,</span> <span class="n">qubit_list</span><span class="p">)</span>
+
+    <span class="k">return</span> <span class="n">circ_prime</span>
+
+<span class="n">DecompseZPass</span> <span class="o">=</span> <span class="n">CustomPass</span><span class="p">(</span><span class="n">z_transform</span><span class="p">)</span> <span class="c1"># Define our pass</span>
+
+<span class="n">test_circ</span> <span class="o">=</span> <span class="n">Circuit</span><span class="p">(</span><span class="mi">2</span><span class="p">)</span> <span class="c1"># Define a test Circuit for our pass</span>
+<span class="n">test_circ</span><span class="o">.</span><span class="n">Z</span><span class="p">(</span><span class="mi">0</span><span class="p">)</span>
+<span class="n">test_circ</span><span class="o">.</span><span class="n">Z</span><span class="p">(</span><span class="mi">1</span><span class="p">)</span>
+<span class="n">test_circ</span><span class="o">.</span><span class="n">CX</span><span class="p">(</span><span class="mi">0</span><span class="p">,</span> <span class="mi">1</span><span class="p">)</span>
+<span class="n">test_circ</span><span class="o">.</span><span class="n">Z</span><span class="p">(</span><span class="mi">1</span><span class="p">)</span>
+<span class="n">test_circ</span><span class="o">.</span><span class="n">CRy</span><span class="p">(</span><span class="mf">0.5</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">1</span><span class="p">)</span>
+
+<span class="n">DecompseZPass</span><span class="o">.</span><span class="n">apply</span><span class="p">(</span><span class="n">test_circ</span><span class="p">)</span> <span class="c1"># Apply our pass to the test Circuit</span>
+
+<span class="n">test_circ</span><span class="o">.</span><span class="n">get_commands</span><span class="p">()</span> <span class="c1"># Commands of our transformed Circuit</span>
+</pre></div>
+</div>
+</div>
+<div class="cell_output docutils container">
+<div class="output text_plain highlight-none notranslate"><div class="highlight"><pre><span></span>[H q[0];,
+ H q[1];,
+ X q[0];,
+ X q[1];,
+ H q[0];,
+ H q[1];,
+ CX q[0], q[1];,
+ H q[1];,
+ X q[1];,
+ H q[1];,
+ CRy(0.5) q[0], q[1];]
+</pre></div>
+</div>
+</div>
+</div>
+<div class="admonition warning">
+<p class="admonition-title">Warning</p>
+<p>pytket does not require that <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> preserves the unitary of the <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code>.</p>
 </div>
 </section>
 <section id="partial-compilation">
@@ -1249,13 +1314,13 @@ the main circuit and the postprocessing circuit, returning both.</p>
 <div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>[[0 0]
  [1 1]
  [1 1]
+ [1 1]
  [0 0]
- [0 0]
  [1 1]
  [1 1]
  [1 1]
  [1 1]
- [1 1]]
+ [0 0]]
 </pre></div>
 </div>
 </div>

--- a/docs/manual/manual_compiler.html
+++ b/docs/manual/manual_compiler.html
@@ -952,7 +952,7 @@ The <code class="xref py py-class docutils literal notranslate"><span class="pre
     <span class="n">circ_prime</span> <span class="o">=</span> <span class="n">Circuit</span><span class="p">(</span><span class="n">n_qubits</span><span class="p">)</span> <span class="c1"># Define a replacement circuit</span>
 
     <span class="k">for</span> <span class="n">cmd</span> <span class="ow">in</span> <span class="n">circ</span><span class="o">.</span><span class="n">get_commands</span><span class="p">():</span>
-        <span class="n">qubit_list</span> <span class="o">=</span> <span class="n">cmd</span><span class="o">.</span><span class="n">qubits</span>
+        <span class="n">qubit_list</span> <span class="o">=</span> <span class="n">cmd</span><span class="o">.</span><span class="n">qubits</span> <span class="c1"># Qubit our gate is applied on (as a list)</span>
         <span class="k">if</span> <span class="n">cmd</span><span class="o">.</span><span class="n">op</span><span class="o">.</span><span class="n">type</span> <span class="o">==</span> <span class="n">OpType</span><span class="o">.</span><span class="n">Z</span><span class="p">:</span> <span class="c1"># If cmd is a Z gate, decompose to a H, X, H sequence.</span>
             <span class="n">circ_prime</span><span class="o">.</span><span class="n">add_gate</span><span class="p">(</span><span class="n">OpType</span><span class="o">.</span><span class="n">H</span><span class="p">,</span> <span class="n">qubit_list</span><span class="p">)</span>
             <span class="n">circ_prime</span><span class="o">.</span><span class="n">add_gate</span><span class="p">(</span><span class="n">OpType</span><span class="o">.</span><span class="n">X</span><span class="p">,</span> <span class="n">qubit_list</span><span class="p">)</span>
@@ -1318,16 +1318,16 @@ the main circuit and the postprocessing circuit, returning both.</p>
 </div>
 </div>
 <div class="cell_output docutils container">
-<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>[[1 1]
+<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>[[0 0]
+ [1 1]
+ [0 0]
  [1 1]
  [1 1]
  [0 0]
  [0 0]
- [1 1]
- [1 1]
  [0 0]
  [0 0]
- [1 1]]
+ [0 0]]
 </pre></div>
 </div>
 </div>

--- a/docs/manual/manual_compiler.html
+++ b/docs/manual/manual_compiler.html
@@ -941,7 +941,7 @@ CXs 3
 <section id="customised-passes">
 <h3>Customised Passes<a class="headerlink" href="#customised-passes" title="Permalink to this heading"></a></h3>
 <p>We have already seen that pytket allows users to combine passes in a desired order using <code class="xref py py-class docutils literal notranslate"><span class="pre">SequencePass</span></code>. An addtional feature is the <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> which allows users to define their own customised circuit transformation using pytket.
-The <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> class accepts a <cite>transform</cite> parameter.This <cite>transform</cite> is a python function that takes a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> as input and returns a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> as output.</p>
+The <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> class accepts a <code class="docutils literal notranslate"><span class="pre">transform</span></code> parameter. This <code class="docutils literal notranslate"><span class="pre">transform</span></code> is a python function that takes a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> as input and returns a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> as output.</p>
 <p>We will show how to use the <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> with a simple Circuit modification that replaces any Pauli Z gate with a Hadamard gate, Pauli X gate, Hadamard gate chain.</p>
 <p>We can now define our <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> using this function and apply it to a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> in the usual way.</p>
 <div class="jupyter_cell jupyter_container docutils container">
@@ -1309,16 +1309,16 @@ the main circuit and the postprocessing circuit, returning both.</p>
 </div>
 </div>
 <div class="cell_output docutils container">
-<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>[[1 1]
- [0 0]
+<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>[[0 0]
  [1 1]
- [0 0]
- [0 0]
- [0 0]
+ [1 1]
  [1 1]
  [0 0]
  [1 1]
- [1 1]]
+ [0 0]
+ [0 0]
+ [1 1]
+ [0 0]]
 </pre></div>
 </div>
 </div>

--- a/docs/manual/manual_compiler.html
+++ b/docs/manual/manual_compiler.html
@@ -61,7 +61,7 @@
 <li class="toctree-l2"><a class="reference internal" href="#initial-and-final-maps">Initial and Final Maps</a></li>
 <li class="toctree-l2"><a class="reference internal" href="#advanced-topics">Advanced Topics</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="#compiling-symbolic-circuits">Compiling Symbolic Circuits</a></li>
-<li class="toctree-l3"><a class="reference internal" href="#customised-passes">Customised Passes</a></li>
+<li class="toctree-l3"><a class="reference internal" href="#user-defined-passes">User-defined Passes</a></li>
 <li class="toctree-l3"><a class="reference internal" href="#partial-compilation">Partial Compilation</a></li>
 <li class="toctree-l3"><a class="reference internal" href="#measurement-reduction">Measurement Reduction</a></li>
 <li class="toctree-l3"><a class="reference internal" href="#contextual-optimisations">Contextual Optimisations</a><ul>
@@ -938,12 +938,12 @@ CXs 3
 <p>Every <code class="xref py py-class docutils literal notranslate"><span class="pre">Backend</span></code> requires <code class="xref py py-class docutils literal notranslate"><span class="pre">NoSymbolsPredicate</span></code>, so it is necessary to instantiate all symbols before running a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code>.</p>
 </div>
 </section>
-<section id="customised-passes">
-<h3>Customised Passes<a class="headerlink" href="#customised-passes" title="Permalink to this heading"></a></h3>
-<p>We have already seen that pytket allows users to combine passes in a desired order using <code class="xref py py-class docutils literal notranslate"><span class="pre">SequencePass</span></code>. An addtional feature is the <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> which allows users to define their own customised circuit transformation using pytket.
+<section id="user-defined-passes">
+<h3>User-defined Passes<a class="headerlink" href="#user-defined-passes" title="Permalink to this heading"></a></h3>
+<p>We have already seen that pytket allows users to combine passes in a desired order using <code class="xref py py-class docutils literal notranslate"><span class="pre">SequencePass</span></code>. An addtional feature is the <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> which allows users to define their own custom circuit transformation using pytket.
 The <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> class accepts a <code class="docutils literal notranslate"><span class="pre">transform</span></code> parameter. This <code class="docutils literal notranslate"><span class="pre">transform</span></code> is a python function that takes a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> as input and returns a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> as output.</p>
-<p>We will show how to use the <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> with a simple Circuit modification that replaces any Pauli Z gate with a Hadamard gate, Pauli X gate, Hadamard gate chain.</p>
-<p>We can now define our <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> using this function and apply it to a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> in the usual way.</p>
+<p>We will show how to use the <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> with a simple tranfromation that replaces any Pauli Z gate in the <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> with a Hadamard gate, Pauli X gate, Hadamard gate chain.</p>
+<p>After we’ve defined our <code class="docutils literal notranslate"><span class="pre">transfrom</span></code> we can construct a <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code>. This pass can then be applied to a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code>.</p>
 <div class="jupyter_cell jupyter_container docutils container">
 <div class="cell_input code_cell docutils container">
 <div class="highlight-ipython3 notranslate"><div class="highlight"><pre><span></span><span class="kn">from</span> <span class="nn">pytket</span> <span class="kn">import</span> <span class="n">Circuit</span><span class="p">,</span> <span class="n">OpType</span>
@@ -997,7 +997,7 @@ The <code class="xref py py-class docutils literal notranslate"><span class="pre
 </div>
 <div class="admonition warning">
 <p class="admonition-title">Warning</p>
-<p>pytket does not require that <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> preserves the unitary of the <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code>.</p>
+<p>pytket does not require that <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> preserves the unitary of the <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> .</p>
 </div>
 </section>
 <section id="partial-compilation">
@@ -1312,12 +1312,12 @@ the main circuit and the postprocessing circuit, returning both.</p>
 <div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>[[0 0]
  [1 1]
  [1 1]
- [1 1]
  [0 0]
  [1 1]
  [0 0]
  [0 0]
  [1 1]
+ [0 0]
  [0 0]]
 </pre></div>
 </div>

--- a/docs/manual/manual_compiler.html
+++ b/docs/manual/manual_compiler.html
@@ -941,7 +941,7 @@ CXs 3
 <section id="user-defined-passes">
 <h3>User-defined Passes<a class="headerlink" href="#user-defined-passes" title="Permalink to this heading"></a></h3>
 <p>We have already seen that pytket allows users to combine passes in a desired order using <code class="xref py py-class docutils literal notranslate"><span class="pre">SequencePass</span></code>. An addtional feature is the <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> which allows users to define their own custom circuit transformation using pytket.
-The <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> class accepts a <code class="docutils literal notranslate"><span class="pre">transform</span></code> parameter. This <code class="docutils literal notranslate"><span class="pre">transform</span></code> is a python function that takes a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> as input and returns a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> as output.</p>
+The <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> class accepts a <code class="docutils literal notranslate"><span class="pre">transform</span></code> parameter, a python function that takes a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> as input and returns a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> as output.</p>
 <p>We will show how to use the <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> with a simple tranfromation that replaces any Pauli Z gate in the <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> with a Hadamard gate, Pauli X gate, Hadamard gate chain.</p>
 <p>After we’ve defined our <code class="docutils literal notranslate"><span class="pre">transfrom</span></code> we can construct a <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code>. This pass can then be applied to a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code>.</p>
 <div class="jupyter_cell jupyter_container docutils container">
@@ -1309,16 +1309,16 @@ the main circuit and the postprocessing circuit, returning both.</p>
 </div>
 </div>
 <div class="cell_output docutils container">
-<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>[[0 0]
+<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>[[1 1]
  [1 1]
- [1 1]
+ [0 0]
+ [0 0]
  [0 0]
  [1 1]
  [0 0]
  [0 0]
- [1 1]
  [0 0]
- [0 0]]
+ [1 1]]
 </pre></div>
 </div>
 </div>

--- a/docs/manual/manual_compiler.html
+++ b/docs/manual/manual_compiler.html
@@ -940,9 +940,9 @@ CXs 3
 </section>
 <section id="customised-passes">
 <h3>Customised Passes<a class="headerlink" href="#customised-passes" title="Permalink to this heading"></a></h3>
-<p>We have already seen that pytket allows users to combine passes in a desired order using <code class="xref py py-class docutils literal notranslate"><span class="pre">SequencePass</span></code>. An addtional feature is the <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> allowing users to define their own customised circuit transformation using pytket.
+<p>We have already seen that pytket allows users to combine passes in a desired order using <code class="xref py py-class docutils literal notranslate"><span class="pre">SequencePass</span></code>. An addtional feature is the <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> which allows users to define their own customised circuit transformation using pytket.
 The <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> class accepts a <cite>transform</cite> parameter.This <cite>transform</cite> is a python function that takes a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> as input and returns a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> as output.</p>
-<p>We will illustrate this using a function which simply replaces Pauli Z gates with a Pauli X and two Hadamard gates.</p>
+<p>We will show how to use the <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> with a simple Circuit modification that replaces any Pauli Z gate with a Hadamard gate, Pauli X gate, Hadamard gate chain.</p>
 <p>We can now define our <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomPass</span></code> using this function and apply it to a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> in the usual way.</p>
 <div class="jupyter_cell jupyter_container docutils container">
 <div class="cell_input code_cell docutils container">
@@ -953,16 +953,14 @@ The <code class="xref py py-class docutils literal notranslate"><span class="pre
     <span class="n">n_qubits</span> <span class="o">=</span> <span class="n">circ</span><span class="o">.</span><span class="n">n_qubits</span>
     <span class="n">circ_prime</span> <span class="o">=</span> <span class="n">Circuit</span><span class="p">(</span><span class="n">n_qubits</span><span class="p">)</span> <span class="c1"># Define a replacement circuit</span>
 
-    <span class="k">for</span> <span class="n">cmd</span> <span class="ow">in</span> <span class="n">circ</span><span class="o">.</span><span class="n">get_commands</span><span class="p">():</span> <span class="c1"># Iterate through all the gates in our input Circuit</span>
-        <span class="n">qubit_list</span> <span class="o">=</span> <span class="n">cmd</span><span class="o">.</span><span class="n">qubits</span> <span class="c1"># Qubit our gate is applied on (as a list)</span>
+    <span class="k">for</span> <span class="n">cmd</span> <span class="ow">in</span> <span class="n">circ</span><span class="o">.</span><span class="n">get_commands</span><span class="p">():</span>
+        <span class="n">qubit_list</span> <span class="o">=</span> <span class="n">cmd</span><span class="o">.</span><span class="n">qubits</span>
         <span class="k">if</span> <span class="n">cmd</span><span class="o">.</span><span class="n">op</span><span class="o">.</span><span class="n">type</span> <span class="o">==</span> <span class="n">OpType</span><span class="o">.</span><span class="n">Z</span><span class="p">:</span> <span class="c1"># If cmd is a Z gate, decompose to a H, X, H sequence.</span>
             <span class="n">circ_prime</span><span class="o">.</span><span class="n">add_gate</span><span class="p">(</span><span class="n">OpType</span><span class="o">.</span><span class="n">H</span><span class="p">,</span> <span class="n">qubit_list</span><span class="p">)</span>
             <span class="n">circ_prime</span><span class="o">.</span><span class="n">add_gate</span><span class="p">(</span><span class="n">OpType</span><span class="o">.</span><span class="n">X</span><span class="p">,</span> <span class="n">qubit_list</span><span class="p">)</span>
             <span class="n">circ_prime</span><span class="o">.</span><span class="n">add_gate</span><span class="p">(</span><span class="n">OpType</span><span class="o">.</span><span class="n">H</span><span class="p">,</span> <span class="n">qubit_list</span><span class="p">)</span>
         <span class="k">else</span><span class="p">:</span>
-            <span class="c1"># Otherwise apply the gate as usual</span>
-            <span class="n">params</span> <span class="o">=</span> <span class="n">cmd</span><span class="o">.</span><span class="n">op</span><span class="o">.</span><span class="n">params</span>
-            <span class="n">circ_prime</span><span class="o">.</span><span class="n">add_gate</span><span class="p">(</span><span class="n">cmd</span><span class="o">.</span><span class="n">op</span><span class="o">.</span><span class="n">type</span><span class="p">,</span> <span class="n">params</span><span class="p">,</span> <span class="n">qubit_list</span><span class="p">)</span>
+            <span class="n">circ_prime</span><span class="o">.</span><span class="n">add_gate</span><span class="p">(</span><span class="n">cmd</span><span class="o">.</span><span class="n">op</span><span class="o">.</span><span class="n">type</span><span class="p">,</span> <span class="n">cmd</span><span class="o">.</span><span class="n">op</span><span class="o">.</span><span class="n">params</span><span class="p">,</span> <span class="n">qubit_list</span><span class="p">)</span> <span class="c1"># Otherwise, apply the gate as usual.</span>
 
     <span class="k">return</span> <span class="n">circ_prime</span>
 
@@ -1311,16 +1309,16 @@ the main circuit and the postprocessing circuit, returning both.</p>
 </div>
 </div>
 <div class="cell_output docutils container">
-<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>[[0 0]
+<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>[[1 1]
+ [0 0]
  [1 1]
- [1 1]
+ [0 0]
+ [0 0]
+ [0 0]
  [1 1]
  [0 0]
  [1 1]
- [1 1]
- [1 1]
- [1 1]
- [0 0]]
+ [1 1]]
 </pre></div>
 </div>
 </div>

--- a/manual/manual_compiler.rst
+++ b/manual/manual_compiler.rst
@@ -763,7 +763,7 @@ After we've defined our ``transfrom`` we can construct a :py:class:`CustomPass`.
 
 
 .. warning::
-    pytket does not require that :py:class:`CustomPass` preserves the unitary of the :py:class:`Circuit` .
+    pytket does not require that :py:class:`CustomPass` preserves the unitary of the :py:class:`Circuit` . This is for the user to ensure.
 
 
 Partial Compilation

--- a/manual/manual_compiler.rst
+++ b/manual/manual_compiler.rst
@@ -724,9 +724,9 @@ User-defined Passes
 We have already seen that pytket allows users to combine passes in a desired order using :py:class:`SequencePass`. An addtional feature is the :py:class:`CustomPass` which allows users to define their own custom circuit transformation using pytket.
 The :py:class:`CustomPass` class accepts a ``transform`` parameter, a python function that takes a :py:class:`Circuit` as input and returns a :py:class:`Circuit` as output. 
 
-We will show how to use :py:class:`CustomPass` by defining a simple tranfromation that replaces any Pauli Z gate in the :py:class:`Circuit` with a Hadamard gate, Pauli X gate, Hadamard gate chain.
+We will show how to use :py:class:`CustomPass` by defining a simple transformation that replaces any Pauli Z gate in the :py:class:`Circuit` with a Hadamard gate, Pauli X gate, Hadamard gate chain.
 
-After we've defined our ``transfrom`` we can construct a :py:class:`CustomPass`. This pass can then be applied to a :py:class:`Circuit`.
+After we've defined our ``transform`` we can construct a :py:class:`CustomPass`. This pass can then be applied to a :py:class:`Circuit`.
 
 .. jupyter-execute::
 

--- a/manual/manual_compiler.rst
+++ b/manual/manual_compiler.rst
@@ -737,7 +737,7 @@ We will show how to use :py:class:`CustomPass` by defining a simple transformati
         circ_prime = Circuit(n_qubits) # Define a replacement circuit
 
         for cmd in circ.get_commands():
-            qubit_list = cmd.qubits
+            qubit_list = cmd.qubits # Qubit our gate is applied on (as a list)
             if cmd.op.type == OpType.Z: # If cmd is a Z gate, decompose to a H, X, H sequence.
                 circ_prime.add_gate(OpType.H, qubit_list)
                 circ_prime.add_gate(OpType.X, qubit_list)

--- a/manual/manual_compiler.rst
+++ b/manual/manual_compiler.rst
@@ -724,7 +724,7 @@ User-defined Passes
 We have already seen that pytket allows users to combine passes in a desired order using :py:class:`SequencePass`. An addtional feature is the :py:class:`CustomPass` which allows users to define their own custom circuit transformation using pytket.
 The :py:class:`CustomPass` class accepts a ``transform`` parameter, a python function that takes a :py:class:`Circuit` as input and returns a :py:class:`Circuit` as output. 
 
-We will show how to use the :py:class:`CustomPass` with a simple tranfromation that replaces any Pauli Z gate in the :py:class:`Circuit` with a Hadamard gate, Pauli X gate, Hadamard gate chain.
+We will show how to use :py:class:`CustomPass` by defining a simple tranfromation that replaces any Pauli Z gate in the :py:class:`Circuit` with a Hadamard gate, Pauli X gate, Hadamard gate chain.
 
 After we've defined our ``transfrom`` we can construct a :py:class:`CustomPass`. This pass can then be applied to a :py:class:`Circuit`.
 

--- a/manual/manual_compiler.rst
+++ b/manual/manual_compiler.rst
@@ -726,8 +726,6 @@ The :py:class:`CustomPass` class accepts a ``transform`` parameter, a python fun
 
 We will show how to use :py:class:`CustomPass` by defining a simple transformation that replaces any Pauli Z gate in the :py:class:`Circuit` with a Hadamard gate, Pauli X gate, Hadamard gate chain.
 
-
-
 .. jupyter-execute::
 
     from pytket import Circuit, OpType
@@ -737,7 +735,7 @@ We will show how to use :py:class:`CustomPass` by defining a simple transformati
         circ_prime = Circuit(n_qubits) # Define a replacement circuit
 
         for cmd in circ.get_commands():
-            qubit_list = cmd.qubits # Qubit our gate is applied on (as a list)
+            qubit_list = cmd.qubits # Qubit(s) our gate is applied on (as a list)
             if cmd.op.type == OpType.Z: # If cmd is a Z gate, decompose to a H, X, H sequence.
                 circ_prime.add_gate(OpType.H, qubit_list)
                 circ_prime.add_gate(OpType.X, qubit_list)

--- a/manual/manual_compiler.rst
+++ b/manual/manual_compiler.rst
@@ -722,7 +722,7 @@ Customised Passes
 =================
 
 We have already seen that pytket allows users to combine passes in a desired order using :py:class:`SequencePass`. An addtional feature is the :py:class:`CustomPass` which allows users to define their own customised circuit transformation using pytket.
-The :py:class:`CustomPass` class accepts a `transform` parameter.This `transform` is a python function that takes a :py:class:`Circuit` as input and returns a :py:class:`Circuit` as output. 
+The :py:class:`CustomPass` class accepts a ``transform`` parameter. This ``transform`` is a python function that takes a :py:class:`Circuit` as input and returns a :py:class:`Circuit` as output. 
 
 We will show how to use the :py:class:`CustomPass` with a simple Circuit modification that replaces any Pauli Z gate with a Hadamard gate, Pauli X gate, Hadamard gate chain.
 
@@ -743,7 +743,7 @@ We can now define our :py:class:`CustomPass` using this function and apply it to
                 circ_prime.add_gate(OpType.H, qubit_list)
                 circ_prime.add_gate(OpType.X, qubit_list)
                 circ_prime.add_gate(OpType.H, qubit_list)
-            else:
+            else: 
                 circ_prime.add_gate(cmd.op.type, cmd.op.params, qubit_list) # Otherwise, apply the gate as usual.
 
         return circ_prime

--- a/manual/manual_compiler.rst
+++ b/manual/manual_compiler.rst
@@ -722,7 +722,7 @@ User-defined Passes
 ===================
 
 We have already seen that pytket allows users to combine passes in a desired order using :py:class:`SequencePass`. An addtional feature is the :py:class:`CustomPass` which allows users to define their own custom circuit transformation using pytket.
-The :py:class:`CustomPass` class accepts a ``transform`` parameter. This ``transform`` is a python function that takes a :py:class:`Circuit` as input and returns a :py:class:`Circuit` as output. 
+The :py:class:`CustomPass` class accepts a ``transform`` parameter, a python function that takes a :py:class:`Circuit` as input and returns a :py:class:`Circuit` as output. 
 
 We will show how to use the :py:class:`CustomPass` with a simple tranfromation that replaces any Pauli Z gate in the :py:class:`Circuit` with a Hadamard gate, Pauli X gate, Hadamard gate chain.
 

--- a/manual/manual_compiler.rst
+++ b/manual/manual_compiler.rst
@@ -721,10 +721,10 @@ For variational algorithms, the prominent benefit of defining a :py:class:`Circu
 Customised Passes
 =================
 
-We have already seen that pytket allows users to combine passes in a desired order using :py:class:`SequencePass`. An addtional feature is the :py:class:`CustomPass` allowing users to define their own customised circuit transformation using pytket.
+We have already seen that pytket allows users to combine passes in a desired order using :py:class:`SequencePass`. An addtional feature is the :py:class:`CustomPass` which allows users to define their own customised circuit transformation using pytket.
 The :py:class:`CustomPass` class accepts a `transform` parameter.This `transform` is a python function that takes a :py:class:`Circuit` as input and returns a :py:class:`Circuit` as output. 
 
-We will illustrate this using a function which simply replaces Pauli Z gates with a Pauli X and two Hadamard gates.
+We will show how to use the :py:class:`CustomPass` with a simple Circuit modification that replaces any Pauli Z gate with a Hadamard gate, Pauli X gate, Hadamard gate chain.
 
 We can now define our :py:class:`CustomPass` using this function and apply it to a :py:class:`Circuit` in the usual way.
 
@@ -737,17 +737,15 @@ We can now define our :py:class:`CustomPass` using this function and apply it to
         n_qubits = circ.n_qubits
         circ_prime = Circuit(n_qubits) # Define a replacement circuit
 
-        for cmd in circ.get_commands(): # Iterate through all the gates in our input Circuit
-            qubit_list = cmd.qubits # Qubit our gate is applied on (as a list)
+        for cmd in circ.get_commands():
+            qubit_list = cmd.qubits
             if cmd.op.type == OpType.Z: # If cmd is a Z gate, decompose to a H, X, H sequence.
                 circ_prime.add_gate(OpType.H, qubit_list)
                 circ_prime.add_gate(OpType.X, qubit_list)
                 circ_prime.add_gate(OpType.H, qubit_list)
-            else: 
-                # Otherwise apply the gate as usual
-                params = cmd.op.params
-                circ_prime.add_gate(cmd.op.type, params, qubit_list) 
-                
+            else:
+                circ_prime.add_gate(cmd.op.type, cmd.op.params, qubit_list) # Otherwise, apply the gate as usual.
+
         return circ_prime
 
     DecompseZPass = CustomPass(z_transform) # Define our pass

--- a/manual/manual_compiler.rst
+++ b/manual/manual_compiler.rst
@@ -726,12 +726,11 @@ The :py:class:`CustomPass` class accepts a ``transform`` parameter, a python fun
 
 We will show how to use :py:class:`CustomPass` by defining a simple transformation that replaces any Pauli Z gate in the :py:class:`Circuit` with a Hadamard gate, Pauli X gate, Hadamard gate chain.
 
-After we've defined our ``transform`` we can construct a :py:class:`CustomPass`. This pass can then be applied to a :py:class:`Circuit`.
+
 
 .. jupyter-execute::
 
     from pytket import Circuit, OpType
-    from pytket.passes import CustomPass
     
     def z_transform(circ):
         n_qubits = circ.n_qubits
@@ -748,6 +747,12 @@ After we've defined our ``transform`` we can construct a :py:class:`CustomPass`.
 
         return circ_prime
 
+After we've defined our ``transform`` we can construct a :py:class:`CustomPass`. This pass can then be applied to a :py:class:`Circuit`.
+
+.. jupyter-execute::
+
+    from pytket.passes import CustomPass
+
     DecompseZPass = CustomPass(z_transform) # Define our pass
 
     test_circ = Circuit(2) # Define a test Circuit for our pass
@@ -761,6 +766,7 @@ After we've defined our ``transform`` we can construct a :py:class:`CustomPass`.
 
     test_circ.get_commands() # Commands of our transformed Circuit
 
+We see from the output above that our newly defined :py:class:`DecompseZPass` has successfully decomposed the Pauli Z gates to Hadamard, Pauli X, Hadamard chains and left other gates unchanged.
 
 .. warning::
     pytket does not require that :py:class:`CustomPass` preserves the unitary of the :py:class:`Circuit` . This is for the user to ensure.

--- a/manual/manual_compiler.rst
+++ b/manual/manual_compiler.rst
@@ -718,15 +718,15 @@ For variational algorithms, the prominent benefit of defining a :py:class:`Circu
 
 .. note:: Every :py:class:`Backend` requires :py:class:`NoSymbolsPredicate`, so it is necessary to instantiate all symbols before running a :py:class:`Circuit`.
 
-Customised Passes
-=================
+User-defined Passes
+===================
 
-We have already seen that pytket allows users to combine passes in a desired order using :py:class:`SequencePass`. An addtional feature is the :py:class:`CustomPass` which allows users to define their own customised circuit transformation using pytket.
+We have already seen that pytket allows users to combine passes in a desired order using :py:class:`SequencePass`. An addtional feature is the :py:class:`CustomPass` which allows users to define their own custom circuit transformation using pytket.
 The :py:class:`CustomPass` class accepts a ``transform`` parameter. This ``transform`` is a python function that takes a :py:class:`Circuit` as input and returns a :py:class:`Circuit` as output. 
 
-We will show how to use the :py:class:`CustomPass` with a simple Circuit modification that replaces any Pauli Z gate with a Hadamard gate, Pauli X gate, Hadamard gate chain.
+We will show how to use the :py:class:`CustomPass` with a simple tranfromation that replaces any Pauli Z gate in the :py:class:`Circuit` with a Hadamard gate, Pauli X gate, Hadamard gate chain.
 
-We can now define our :py:class:`CustomPass` using this function and apply it to a :py:class:`Circuit` in the usual way.
+After we've defined our ``transfrom`` we can construct a :py:class:`CustomPass`. This pass can then be applied to a :py:class:`Circuit`.
 
 .. jupyter-execute::
 
@@ -763,7 +763,7 @@ We can now define our :py:class:`CustomPass` using this function and apply it to
 
 
 .. warning::
-    pytket does not require that :py:class:`CustomPass` preserves the unitary of the :py:class:`Circuit`.
+    pytket does not require that :py:class:`CustomPass` preserves the unitary of the :py:class:`Circuit` .
 
 
 Partial Compilation


### PR DESCRIPTION
I've added a brief manual section on Alec's `CustomPass` feature. I've put this under advanced topics, let me know if this is the appropriate place.

The pass I've defined performs a pretty trivial transformation from Z to {X,H} and otherwise does nothing. I'm not that satisfied with the function as it feels overly complex for something so simple. Let me know if another example would be preferred.

I've tried out more interesting transformations but maybe its best to go with something easy for the manual. 