### PR TITLE
remove blank line in quipper string

### DIFF
--- a/examples/python/circuit_generation_example.py
+++ b/examples/python/circuit_generation_example.py
@@ -108,7 +108,6 @@ QGate["H"](0)
 Subroutine(x2)["sub", shape "([Q,Q],())"] (2,1) -> (2,1)
 QGate["H"](1)
 Outputs: 0:Qbit, 1:Qbit, 2:Qbit
-
 Subroutine: "sub"
 Shape: "([Q,Q],())"
 Controllable: no


### PR DESCRIPTION
Small PR to fix an error in the circuit generation notebook.

Previously there was a blank line in the middle of the quipper string. 

This led to the string being separated into two different cells in the p2j generated jupyter notebook and means the quipper string is invalid.