### PR TITLE
add continue-on-error: true

### DIFF
--- a/.github/workflows/check-manual.yml
+++ b/.github/workflows/check-manual.yml
@@ -51,6 +51,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install graphviz
     - name: build manual
+      continue-on-error: true
       run: |
         cd manual/
         sed "s/REQUIREMENTS/$(sed -e 's/[\&/]/\\&/g' -e 's/$/\\n/' ../requirements.txt | tr -d '\n')/" index-rst-template > index.rst


### PR DESCRIPTION
Added a line to the check manual workflow to ensure that the CI run continues on error instead of quitting. 

This is so that we can see error messages on the CI instead of the build just failing.