### PR TITLE
Revert "add continue-on-error: true"

### DIFF
--- a/.github/workflows/check-manual.yml
+++ b/.github/workflows/check-manual.yml
@@ -51,7 +51,6 @@ jobs:
         sudo apt-get update
         sudo apt-get install graphviz
     - name: build manual
-      continue-on-error: true
       run: |
         cd manual/
         sed "s/REQUIREMENTS/$(sed -e 's/[\&/]/\\&/g' -e 's/$/\\n/' ../requirements.txt | tr -d '\n')/" index-rst-template > index.rst


### PR DESCRIPTION
Reverts CQCL/pytket#190

remove `continue-on-error: true` from build-manual