### PR TITLE
Fix diagrams and Update Headings 

### DIFF
--- a/docs/manual/manual_backend.html
+++ b/docs/manual/manual_backend.html
@@ -346,13 +346,13 @@ document.write(`
                 <ul class="visible nav section-nav flex-column">
 <li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#backend-requirements">Backend Requirements</a></li>
 <li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#shots-and-sampling">Shots and Sampling</a></li>
-<li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#statevectors-and-unitaries">Statevectors and Unitaries</a></li>
+<li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#statevector-and-unitary-simulation-with-tket-backends">Statevector and Unitary Simulation with TKET Backends</a></li>
 <li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#interpreting-results">Interpreting Results</a></li>
 <li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#expectation-value-calculations">Expectation Value Calculations</a></li>
 <li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#guidance-for-writing-hardware-agnostic-code">Guidance for Writing Hardware-Agnostic Code</a></li>
 <li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#batch-submission">Batch Submission</a></li>
 <li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#embedding-into-qiskit">Embedding into Qiskit</a></li>
-<li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#advanced-topics">Advanced Topics</a><ul class="nav section-nav flex-column">
+<li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#advanced-backend-topics">Advanced Backend Topics</a><ul class="nav section-nav flex-column">
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#simulator-support-for-expectation-values">Simulator Support for Expectation Values</a></li>
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#asynchronous-job-submission">Asynchronous Job Submission</a></li>
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#persistent-handles">Persistent Handles</a></li>
@@ -463,25 +463,25 @@ document.write(`
 </div>
 </div>
 <div class="cell_output docutils container">
-<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>[[0 1]
- [0 1]
- [1 1]
+<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>[[1 1]
  [0 1]
  [0 1]
- [1 1]
- [1 1]
- [1 1]
- [1 1]
  [0 1]
  [1 1]
- [0 1]
- [0 1]
  [1 1]
  [0 1]
  [0 1]
  [0 1]
  [1 1]
  [1 1]
+ [0 1]
+ [0 1]
+ [1 1]
+ [0 1]
+ [1 1]
+ [1 1]
+ [0 1]
+ [0 1]
  [0 1]]
 </pre></div>
 </div>
@@ -509,8 +509,8 @@ document.write(`
 </div>
 </div>
 <div class="cell_output docutils container">
-<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>Counter({(0, 1): 1025, (1, 1): 975})
-{(0, 1): 0.5125, (1, 1): 0.4875}
+<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>Counter({(1, 1): 1038, (0, 1): 962})
+{(0, 1): 0.481, (1, 1): 0.519}
 </pre></div>
 </div>
 </div>
@@ -520,8 +520,8 @@ document.write(`
 <p><code class="xref py py-meth docutils literal notranslate"><span class="pre">Backend.process_circuit()</span></code> returns a handle to the computation to perform the quantum computation asynchronously. Non-blocking operations are essential when running circuits on remote devices, as submission and queuing times can be long. The handle may then be used to retrieve the results with <code class="xref py py-meth docutils literal notranslate"><span class="pre">Backend.get_result()</span></code>. If asynchronous computation is not needed, for example when running on a local simulator, pytket provides the shortcut <cite>Backend.run_circuit</cite> that will immediately execute the circuit and return a <code class="xref py py-class docutils literal notranslate"><span class="pre">BackendResult</span></code>.</p>
 </div>
 </section>
-<section id="statevectors-and-unitaries">
-<h2>Statevectors and Unitaries<a class="headerlink" href="#statevectors-and-unitaries" title="Permalink to this heading">#</a></h2>
+<section id="statevector-and-unitary-simulation-with-tket-backends">
+<h2>Statevector and Unitary Simulation with TKET Backends<a class="headerlink" href="#statevector-and-unitary-simulation-with-tket-backends" title="Permalink to this heading">#</a></h2>
 <p>Any form of sampling from a distribution will introduce sampling error and (unless it is a seeded simulator) non-deterministic results, whereas we could get much better accuracy and repeatability if we have the exact state of the underlying physical quantum system. Some simulators will provide direct access to this. The <code class="xref py py-meth docutils literal notranslate"><span class="pre">BackendResult.get_state()</span></code> method will give the full representation of the physical state as a vector in the <span class="math notranslate nohighlight">\(2^n\)</span>-dimensional Hilbert space, whenever the underlying simulator provides this.</p>
 <div class="jupyter_cell jupyter_container docutils container">
 <div class="cell_input code_cell docutils container">
@@ -684,7 +684,7 @@ Counter({(1, 0): 10})
 </div>
 </div>
 <div class="cell_output docutils container">
-<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>0.0
+<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>0.020000000000000018
 </pre></div>
 </div>
 </div>
@@ -745,8 +745,8 @@ Counter({(1, 0): 10})
   0.63003676-3.85786248e-17j -0.32101976+3.93135823e-17j
   0.        +0.00000000e+00j  0.        +0.00000000e+00j
   0.        +0.00000000e+00j  0.        +0.00000000e+00j]
-Counter({(1, 0, 0): 804, (0, 0, 0): 772, (0, 0, 1): 213, (1, 0, 1): 211})
-Counter({(0, 0): 1576, (0, 1): 424})
+Counter({(0, 0, 0): 797, (1, 0, 0): 778, (1, 0, 1): 215, (0, 0, 1): 210})
+Counter({(0, 0): 1575, (0, 1): 425})
 </pre></div>
 </div>
 </div>
@@ -794,10 +794,11 @@ Counter({(0, 0): 1576, (0, 1): 424})
 </div>
 </div>
 <div class="cell_output docutils container">
-<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>-0.0129999999999999
+<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>-0.050000000000000044
 </pre></div>
 </div>
-<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>(0.317+0j)
+<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>
+(0.29+0j)
 </pre></div>
 </div>
 </div>
@@ -826,8 +827,8 @@ Counter({(0, 0): 1576, (0, 1): 424})
 </div>
 </div>
 <div class="cell_output docutils container">
-<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>Counter({(0, 0, 0): 453, (0, 1, 1): 405, (0, 0, 1): 381, (0, 1, 0): 375, (1, 1, 0): 106, (1, 1, 1): 100, (1, 0, 0): 95, (1, 0, 1): 85})
-0.049000000000000044
+<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>Counter({(0, 0, 1): 446, (0, 1, 0): 418, (0, 0, 0): 407, (0, 1, 1): 342, (1, 0, 0): 104, (1, 1, 0): 102, (1, 1, 1): 97, (1, 0, 1): 84})
+-0.06499999999999995
 </pre></div>
 </div>
 </div>
@@ -867,7 +868,7 @@ Counter({(0, 0): 1576, (0, 1): 424})
 </div>
 </div>
 <div class="cell_output docutils container">
-<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>Counter({(0, 1, 1): 145, (1, 1, 1): 131, (0, 1, 0): 126, (1, 1, 0): 125, (0, 0, 0): 122, (0, 0, 1): 122, (1, 0, 1): 115, (1, 0, 0): 114})
+<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>Counter({(1, 0, 1): 134, (0, 0, 1): 130, (0, 1, 0): 130, (0, 0, 0): 126, (1, 1, 0): 125, (1, 0, 0): 124, (1, 1, 1): 119, (0, 1, 1): 112})
 </pre></div>
 </div>
 </div>
@@ -921,7 +922,7 @@ Counter({(0, 0): 1576, (0, 1): 424})
 </div>
 </div>
 <div class="cell_output docutils container">
-<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>-0.004999999999999893
+<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>-0.02400000000000002
 </pre></div>
 </div>
 </div>
@@ -1027,8 +1028,8 @@ Counter({(0, 0): 1576, (0, 1): 424})
 <p>Since Qiskit may not be able to solve all of the constraints of the chosen device/simulator, some compilation may be required after a circuit is passed to the <code class="xref py py-class docutils literal notranslate"><span class="pre">TketBackend</span></code>, or it may just be preferable to do so to take advantage of the sophisticated compilation solutions provided in <code class="docutils literal notranslate"><span class="pre">pytket</span></code>. Upon constructing the <code class="xref py py-class docutils literal notranslate"><span class="pre">TketBackend</span></code>, you can provide a <code class="docutils literal notranslate"><span class="pre">pytket</span></code> compilation pass to apply to each circuit, e.g. <code class="docutils literal notranslate"><span class="pre">TketBackend(backend,</span> <span class="pre">backend.default_compilation_pass())</span></code>. Some experimentation may be required to find a combination of <code class="docutils literal notranslate"><span class="pre">qiskit.transpiler.PassManager</span></code> and <code class="docutils literal notranslate"><span class="pre">pytket</span></code> compilation passes that executes successfully.</p>
 </div>
 </section>
-<section id="advanced-topics">
-<h2>Advanced Topics<a class="headerlink" href="#advanced-topics" title="Permalink to this heading">#</a></h2>
+<section id="advanced-backend-topics">
+<h2>Advanced Backend Topics<a class="headerlink" href="#advanced-backend-topics" title="Permalink to this heading">#</a></h2>
 <section id="simulator-support-for-expectation-values">
 <h3>Simulator Support for Expectation Values<a class="headerlink" href="#simulator-support-for-expectation-values" title="Permalink to this heading">#</a></h3>
 <p>Some simulators will have dedicated support for fast expectation value calculations. In this special case, they will provide extra methods <code class="xref py py-meth docutils literal notranslate"><span class="pre">Backend.get_pauli_expectation_value()</span></code> and <code class="xref py py-meth docutils literal notranslate"><span class="pre">Backend.get_operator_expectation_value()</span></code>, which take a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> and some operator and directly return the expectation value. Again, we can check whether a <code class="xref py py-class docutils literal notranslate"><span class="pre">Backend</span></code> has this feature with <code class="xref py py-attr docutils literal notranslate"><span class="pre">Backend.supports_expectation</span></code>.</p>
@@ -1230,7 +1231,7 @@ This can be achieved using native serialiaztion and deserialization of <code cla
 </div>
 </div>
 <div class="cell_output docutils container">
-<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>Counter({(0, 0): 6, (1, 1): 4})
+<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>Counter({(0, 0): 5, (1, 1): 5})
 </pre></div>
 </div>
 </div>
@@ -1299,13 +1300,13 @@ This can be achieved using native serialiaztion and deserialization of <code cla
     <ul class="visible nav section-nav flex-column">
 <li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#backend-requirements">Backend Requirements</a></li>
 <li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#shots-and-sampling">Shots and Sampling</a></li>
-<li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#statevectors-and-unitaries">Statevectors and Unitaries</a></li>
+<li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#statevector-and-unitary-simulation-with-tket-backends">Statevector and Unitary Simulation with TKET Backends</a></li>
 <li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#interpreting-results">Interpreting Results</a></li>
 <li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#expectation-value-calculations">Expectation Value Calculations</a></li>
 <li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#guidance-for-writing-hardware-agnostic-code">Guidance for Writing Hardware-Agnostic Code</a></li>
 <li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#batch-submission">Batch Submission</a></li>
 <li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#embedding-into-qiskit">Embedding into Qiskit</a></li>
-<li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#advanced-topics">Advanced Topics</a><ul class="nav section-nav flex-column">
+<li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#advanced-backend-topics">Advanced Backend Topics</a><ul class="nav section-nav flex-column">
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#simulator-support-for-expectation-values">Simulator Support for Expectation Values</a></li>
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#asynchronous-job-submission">Asynchronous Job Submission</a></li>
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#persistent-handles">Persistent Handles</a></li>

--- a/docs/manual/manual_circuit.html
+++ b/docs/manual/manual_circuit.html
@@ -369,7 +369,7 @@ document.write(`
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#clifford-tableaux">Clifford Tableaux</a></li>
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#classical-and-conditional-operations">Classical and conditional operations</a></li>
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#circuit-level-operations">Circuit-Level Operations</a></li>
-<li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#id9">Implicit Qubit Permutations</a></li>
+<li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#implicit-qubit-permutations">Implicit Qubit Permutations</a></li>
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#modifying-operations-within-circuits">Modifying Operations Within Circuits</a></li>
 </ul>
 </li>
@@ -976,7 +976,7 @@ X OpType.X [q[1]]
 
 
 
-    &lt;div id=&#34;circuit-display-vue-container-d5512ccb-33c7-464e-afdb-b471c9be6bee&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
+    &lt;div id=&#34;circuit-display-vue-container-de71819a-3c3c-4835-b77f-4b8b819317af&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
         &lt;div style=&#34;display: none&#34;&gt;
             &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.3&#34;], &#34;type&#34;: &#34;Rx&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;CZ&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
         &lt;/div&gt;
@@ -986,7 +986,7 @@ X OpType.X [q[1]]
         &gt;&lt;/circuit-display-container&gt;
     &lt;/div&gt;
     &lt;script type=&#34;application/javascript&#34;&gt;
-      const circuitRendererUid = &#34;d5512ccb-33c7-464e-afdb-b471c9be6bee&#34;;
+      const circuitRendererUid = &#34;de71819a-3c3c-4835-b77f-4b8b819317af&#34;;
       const displayOptions = JSON.parse(&#39;{}&#39;);
 
       // Script to initialise the circuit renderer app
@@ -1134,7 +1134,7 @@ Circuit depth = 3
 
 
 
-    &lt;div id=&#34;circuit-display-vue-container-d5b6d47f-535e-40a6-98c6-15915f72ab6c&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
+    &lt;div id=&#34;circuit-display-vue-container-f689b998-291c-45dd-9768-7e12b56d99ca&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
         &lt;div style=&#34;display: none&#34;&gt;
             &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;T&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;n_qb&#34;: 3, &#34;params&#34;: [&#34;0.6&#34;], &#34;type&#34;: &#34;CnRy&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CZ&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;T&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;CZ&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;T&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
         &lt;/div&gt;
@@ -1144,7 +1144,7 @@ Circuit depth = 3
         &gt;&lt;/circuit-display-container&gt;
     &lt;/div&gt;
     &lt;script type=&#34;application/javascript&#34;&gt;
-      const circuitRendererUid = &#34;d5b6d47f-535e-40a6-98c6-15915f72ab6c&#34;;
+      const circuitRendererUid = &#34;f689b998-291c-45dd-9768-7e12b56d99ca&#34;;
       const displayOptions = JSON.parse(&#39;{}&#39;);
 
       // Script to initialise the circuit renderer app
@@ -1243,7 +1243,7 @@ it to another circuit as part of a larger algorithm.</p>
 
 
 
-    &lt;div id=&#34;circuit-display-vue-container-d3c06bd6-1c74-4b00-bfd1-16002620e5e8&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
+    &lt;div id=&#34;circuit-display-vue-container-b715c4d4-03dc-47ef-ba2c-a2b7ce28adc6&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
         &lt;div style=&#34;display: none&#34;&gt;
             &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;n_qb&#34;: 3, &#34;type&#34;: &#34;CnZ&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;name&#34;: &#34;Oracle&#34;, &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
         &lt;/div&gt;
@@ -1253,7 +1253,7 @@ it to another circuit as part of a larger algorithm.</p>
         &gt;&lt;/circuit-display-container&gt;
     &lt;/div&gt;
     &lt;script type=&#34;application/javascript&#34;&gt;
-      const circuitRendererUid = &#34;d3c06bd6-1c74-4b00-bfd1-16002620e5e8&#34;;
+      const circuitRendererUid = &#34;b715c4d4-03dc-47ef-ba2c-a2b7ce28adc6&#34;;
       const displayOptions = JSON.parse(&#39;{}&#39;);
 
       // Script to initialise the circuit renderer app
@@ -1327,9 +1327,9 @@ window.pytketCircuitDisplays[circuitRendererUid] = app;
 
 
 
-    &lt;div id=&#34;circuit-display-vue-container-b960bb93-49d7-473a-8ea8-084ce12fd812&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
+    &lt;div id=&#34;circuit-display-vue-container-7374b8cc-01bd-4d14-85a4-e773d3e6bd54&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
         &lt;div style=&#34;display: none&#34;&gt;
-            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;circuit&#34;: {&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;n_qb&#34;: 3, &#34;type&#34;: &#34;CnZ&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;name&#34;: &#34;Oracle&#34;, &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}, &#34;id&#34;: &#34;67750411-1709-4bf7-8dce-936aff87706d&#34;, &#34;type&#34;: &#34;CircBox&#34;}, &#34;type&#34;: &#34;CircBox&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
+            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;circuit&#34;: {&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;n_qb&#34;: 3, &#34;type&#34;: &#34;CnZ&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;name&#34;: &#34;Oracle&#34;, &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}, &#34;id&#34;: &#34;1b7f835e-ebca-4a7d-98c0-f6454d786c1a&#34;, &#34;type&#34;: &#34;CircBox&#34;}, &#34;type&#34;: &#34;CircBox&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
         &lt;/div&gt;
         &lt;circuit-display-container
                 :circuit-element-str=&#34;&#39;#circuit-json-to-display&#39;&#34;
@@ -1337,7 +1337,7 @@ window.pytketCircuitDisplays[circuitRendererUid] = app;
         &gt;&lt;/circuit-display-container&gt;
     &lt;/div&gt;
     &lt;script type=&#34;application/javascript&#34;&gt;
-      const circuitRendererUid = &#34;b960bb93-49d7-473a-8ea8-084ce12fd812&#34;;
+      const circuitRendererUid = &#34;7374b8cc-01bd-4d14-85a4-e773d3e6bd54&#34;;
       const displayOptions = JSON.parse(&#39;{}&#39;);
 
       // Script to initialise the circuit renderer app
@@ -1545,7 +1545,7 @@ e^{-i \frac{\pi}{2} \theta P}\,, \quad P \in \{I, X, Y, Z\}^{\otimes n}
 
 
 
-    &lt;div id=&#34;circuit-display-vue-container-2088cbc3-f8f3-4896-8e86-8c3e1a32d004&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
+    &lt;div id=&#34;circuit-display-vue-container-616c5898-84d9-4174-8309-974586b7f15e&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
         &lt;div style=&#34;display: none&#34;&gt;
             &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;V&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [3]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [3]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.7&#34;], &#34;type&#34;: &#34;Rz&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [3]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;Vdg&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [3]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]], [[&#34;q&#34;, [3]], [&#34;q&#34;, [3]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]], [&#34;q&#34;, [3]]]}&lt;/div&gt;
         &lt;/div&gt;
@@ -1555,7 +1555,7 @@ e^{-i \frac{\pi}{2} \theta P}\,, \quad P \in \{I, X, Y, Z\}^{\otimes n}
         &gt;&lt;/circuit-display-container&gt;
     &lt;/div&gt;
     &lt;script type=&#34;application/javascript&#34;&gt;
-      const circuitRendererUid = &#34;2088cbc3-f8f3-4896-8e86-8c3e1a32d004&#34;;
+      const circuitRendererUid = &#34;616c5898-84d9-4174-8309-974586b7f15e&#34;;
       const displayOptions = JSON.parse(&#39;{}&#39;);
 
       // Script to initialise the circuit renderer app
@@ -1657,7 +1657,7 @@ C: |x\rangle \longmapsto e^{2\pi i p(x)}|g(x)\rangle
 
 
 
-    &lt;div id=&#34;circuit-display-vue-container-e3ec09eb-68a2-405f-b568-b1179a8ccbb2&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
+    &lt;div id=&#34;circuit-display-vue-container-65312582-6a50-4760-9c22-fd45ac7acc3b&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
         &lt;div style=&#34;display: none&#34;&gt;
             &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;params&#34;: [&#34;1.05&#34;], &#34;type&#34;: &#34;Rz&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.05&#34;], &#34;type&#34;: &#34;Rz&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.333&#34;], &#34;type&#34;: &#34;Rz&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
         &lt;/div&gt;
@@ -1667,7 +1667,7 @@ C: |x\rangle \longmapsto e^{2\pi i p(x)}|g(x)\rangle
         &gt;&lt;/circuit-display-container&gt;
     &lt;/div&gt;
     &lt;script type=&#34;application/javascript&#34;&gt;
-      const circuitRendererUid = &#34;e3ec09eb-68a2-405f-b568-b1179a8ccbb2&#34;;
+      const circuitRendererUid = &#34;65312582-6a50-4760-9c22-fd45ac7acc3b&#34;;
       const displayOptions = JSON.parse(&#39;{}&#39;);
 
       // Script to initialise the circuit renderer app
@@ -1760,9 +1760,9 @@ To create a multiplexor we simply construct a dictionary where the keys are the 
 
 
 
-    &lt;div id=&#34;circuit-display-vue-container-02b55e93-db90-4ec8-a308-7037d15ddc45&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
+    &lt;div id=&#34;circuit-display-vue-container-024cd44a-4693-4243-a1c1-82cf68290251&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
         &lt;div style=&#34;display: none&#34;&gt;
-            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;81926e64-90fc-4c72-bf49-e066a162b4ed&#34;, &#34;op_map&#34;: [[[false, false], {&#34;params&#34;: [&#34;0.3&#34;], &#34;type&#34;: &#34;Rz&#34;}], [[true, true], {&#34;type&#34;: &#34;H&#34;}]], &#34;type&#34;: &#34;MultiplexorBox&#34;}, &#34;type&#34;: &#34;MultiplexorBox&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
+            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;5eca2085-46de-4a71-87da-4108c3f8e050&#34;, &#34;op_map&#34;: [[[false, false], {&#34;params&#34;: [&#34;0.3&#34;], &#34;type&#34;: &#34;Rz&#34;}], [[true, true], {&#34;type&#34;: &#34;H&#34;}]], &#34;type&#34;: &#34;MultiplexorBox&#34;}, &#34;type&#34;: &#34;MultiplexorBox&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
         &lt;/div&gt;
         &lt;circuit-display-container
                 :circuit-element-str=&#34;&#39;#circuit-json-to-display&#39;&#34;
@@ -1770,7 +1770,7 @@ To create a multiplexor we simply construct a dictionary where the keys are the 
         &gt;&lt;/circuit-display-container&gt;
     &lt;/div&gt;
     &lt;script type=&#34;application/javascript&#34;&gt;
-      const circuitRendererUid = &#34;02b55e93-db90-4ec8-a308-7037d15ddc45&#34;;
+      const circuitRendererUid = &#34;024cd44a-4693-4243-a1c1-82cf68290251&#34;;
       const displayOptions = JSON.parse(&#39;{}&#39;);
 
       // Script to initialise the circuit renderer app
@@ -1955,9 +1955,9 @@ In pytket however, the permutation is implemented efficently using a sequence of
 
 
 
-    &lt;div id=&#34;circuit-display-vue-container-4b78b01a-ac64-425a-a76a-7e2eb8545bab&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
+    &lt;div id=&#34;circuit-display-vue-container-863eb94f-7156-421f-9f7e-3fe986713b5e&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
         &lt;div style=&#34;display: none&#34;&gt;
-            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [2]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;c63bc2b1-026c-43cb-9687-bc27d4c52726&#34;, &#34;op_map&#34;: [[[false, true], {&#34;params&#34;: [&#34;1&#34;], &#34;type&#34;: &#34;Ry&#34;}]], &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}, &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [2]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;48d57f2e-0694-489e-a7d7-09479c80e051&#34;, &#34;op_map&#34;: [[[true, true], {&#34;params&#34;: [&#34;1&#34;], &#34;type&#34;: &#34;Ry&#34;}]], &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}, &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [2]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;ddea3a65-eeb6-4706-830f-96a2c28303f7&#34;, &#34;op_map&#34;: [[[false, false], {&#34;params&#34;: [&#34;1&#34;], &#34;type&#34;: &#34;Ry&#34;}], [[false, true], {&#34;params&#34;: [&#34;1&#34;], &#34;type&#34;: &#34;Ry&#34;}]], &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}, &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;diagonal&#34;: [[[-1.0, 0.0]], [[1.0, 0.0]], [[1.0, 0.0]], [[1.0, 0.0]], [[1.0, 0.0]], [[-1.0, 0.0]], [[1.0, 0.0]], [[1.0, 0.0]]], &#34;id&#34;: &#34;41562ba1-03ca-4155-9876-5cd9bec9ccc0&#34;, &#34;type&#34;: &#34;DiagonalBox&#34;, &#34;upper_triangle&#34;: true}, &#34;type&#34;: &#34;DiagonalBox&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
+            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [2]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;bad777b6-8587-49fd-bd0d-5fddae650d7f&#34;, &#34;op_map&#34;: [[[false, true], {&#34;params&#34;: [&#34;1&#34;], &#34;type&#34;: &#34;Ry&#34;}]], &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}, &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [2]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;5e5125b0-8207-4a92-8aa9-0f64e6cd444f&#34;, &#34;op_map&#34;: [[[true, true], {&#34;params&#34;: [&#34;1&#34;], &#34;type&#34;: &#34;Ry&#34;}]], &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}, &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [2]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;b04e5ce7-6834-4fdf-b409-b7fdc1e1e79d&#34;, &#34;op_map&#34;: [[[false, false], {&#34;params&#34;: [&#34;1&#34;], &#34;type&#34;: &#34;Ry&#34;}], [[false, true], {&#34;params&#34;: [&#34;1&#34;], &#34;type&#34;: &#34;Ry&#34;}]], &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}, &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;diagonal&#34;: [[[-1.0, 0.0]], [[1.0, 0.0]], [[1.0, 0.0]], [[1.0, 0.0]], [[1.0, 0.0]], [[-1.0, 0.0]], [[1.0, 0.0]], [[1.0, 0.0]]], &#34;id&#34;: &#34;9366c398-5f4e-497e-9931-6db51eebb29a&#34;, &#34;type&#34;: &#34;DiagonalBox&#34;, &#34;upper_triangle&#34;: true}, &#34;type&#34;: &#34;DiagonalBox&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
         &lt;/div&gt;
         &lt;circuit-display-container
                 :circuit-element-str=&#34;&#39;#circuit-json-to-display&#39;&#34;
@@ -1965,7 +1965,7 @@ In pytket however, the permutation is implemented efficently using a sequence of
         &gt;&lt;/circuit-display-container&gt;
     &lt;/div&gt;
     &lt;script type=&#34;application/javascript&#34;&gt;
-      const circuitRendererUid = &#34;4b78b01a-ac64-425a-a76a-7e2eb8545bab&#34;;
+      const circuitRendererUid = &#34;863eb94f-7156-421f-9f7e-3fe986713b5e&#34;;
       const displayOptions = JSON.parse(&#39;{}&#39;);
 
       // Script to initialise the circuit renderer app
@@ -2033,9 +2033,9 @@ window.pytketCircuitDisplays[circuitRendererUid] = app;
 
 
 
-    &lt;div id=&#34;circuit-display-vue-container-3f44d1aa-e0f9-4e94-9d35-5c2ac54142dc&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
+    &lt;div id=&#34;circuit-display-vue-container-a5db4be2-72ed-40da-a510-a0ae236eb101&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
         &lt;div style=&#34;display: none&#34;&gt;
-            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;d04c1dcd-21a7-4f62-bb54-6e114cc063b4&#34;, &#34;is_inverse&#34;: false, &#34;statevector&#34;: [[[0.0, 0.0]], [[0.5773502691896258, 0.0]], [[0.5773502691896258, 0.0]], [[0.0, 0.0]], [[0.5773502691896258, 0.0]], [[0.0, 0.0]], [[0.0, 0.0]], [[0.0, 0.0]]], &#34;type&#34;: &#34;StatePreparationBox&#34;}, &#34;type&#34;: &#34;StatePreparationBox&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;67c66fe9-1a7c-4a4b-a550-debb9f6a7184&#34;, &#34;permutation&#34;: [[[false, false, false], [true, false, false]], [[false, false, true], [true, true, true]], [[true, false, false], [false, false, false]], [[true, true, true], [false, false, true]]], &#34;rotation_axis&#34;: &#34;Ry&#34;, &#34;type&#34;: &#34;ToffoliBox&#34;}, &#34;type&#34;: &#34;ToffoliBox&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
+            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;ce118aaf-40ef-470a-844b-dd6ad6c9af0d&#34;, &#34;is_inverse&#34;: false, &#34;statevector&#34;: [[[0.0, 0.0]], [[0.5773502691896258, 0.0]], [[0.5773502691896258, 0.0]], [[0.0, 0.0]], [[0.5773502691896258, 0.0]], [[0.0, 0.0]], [[0.0, 0.0]], [[0.0, 0.0]]], &#34;type&#34;: &#34;StatePreparationBox&#34;}, &#34;type&#34;: &#34;StatePreparationBox&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;58441fbd-2be8-491d-8b59-42134308d017&#34;, &#34;permutation&#34;: [[[false, false, false], [true, false, false]], [[false, false, true], [true, true, true]], [[true, false, false], [false, false, false]], [[true, true, true], [false, false, true]]], &#34;rotation_axis&#34;: &#34;Ry&#34;, &#34;type&#34;: &#34;ToffoliBox&#34;}, &#34;type&#34;: &#34;ToffoliBox&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
         &lt;/div&gt;
         &lt;circuit-display-container
                 :circuit-element-str=&#34;&#39;#circuit-json-to-display&#39;&#34;
@@ -2043,7 +2043,7 @@ window.pytketCircuitDisplays[circuitRendererUid] = app;
         &gt;&lt;/circuit-display-container&gt;
     &lt;/div&gt;
     &lt;script type=&#34;application/javascript&#34;&gt;
-      const circuitRendererUid = &#34;3f44d1aa-e0f9-4e94-9d35-5c2ac54142dc&#34;;
+      const circuitRendererUid = &#34;a5db4be2-72ed-40da-a510-a0ae236eb101&#34;;
       const displayOptions = JSON.parse(&#39;{}&#39;);
 
       // Script to initialise the circuit renderer app
@@ -2175,7 +2175,7 @@ measure q[1] -&gt; c[1];
 </div>
 <div class="admonition note">
 <p class="admonition-title">Note</p>
-<p>The OpenQASM converters do not support circuits with <a class="reference external" href="https://cqcl.github.io/pytket/manual/manual_circuit.html#id9">implicit qubit permutations</a> . This means that if a circuit contains such a permutation it will be ignored when exported to OpenQASM format.</p>
+<p>The OpenQASM converters do not support circuits with <a class="reference internal" href="#implicit-qubit-permutations"><span class="std std-ref">implicit qubit permutations</span></a>. This means that if a circuit contains such a permutation it will be ignored when exported to OpenQASM format.</p>
 </div>
 <p>The core <code class="docutils literal notranslate"><span class="pre">pytket</span></code> package additionally features a converter from Quipper, another circuit description language.</p>
 <div class="jupyter_cell jupyter_container docutils container">
@@ -2687,8 +2687,8 @@ can support the full range of expressions and comparisons shown above.</p>
 <p>Since it is not possible to construct the inverse of an arbitrary POVM, the <code class="xref py py-meth docutils literal notranslate"><span class="pre">Circuit.dagger()</span></code> and <code class="xref py py-meth docutils literal notranslate"><span class="pre">Circuit.transpose()</span></code> methods will fail if there are any measurements, resets, or other operations that they cannot directly invert.</p>
 </div>
 </section>
-<section id="id9">
-<h3>Implicit Qubit Permutations<a class="headerlink" href="#id9" title="Permalink to this heading">#</a></h3>
+<section id="implicit-qubit-permutations">
+<h3>Implicit Qubit Permutations<a class="headerlink" href="#implicit-qubit-permutations" title="Permalink to this heading">#</a></h3>
 <p>The <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> class is built as a DAG to help follow the paths of resources and represent the circuit canonically up to trivial commutations. Each of the edges represents a resource passing from one instruction to the next, so we could represent SWAPs (and general permutations) by connecting the predecessors of the SWAP instruction to the opposite successors. This eliminates the SWAP instruction from the graph (meaning we would no longer perform the operation at runtime) and could enable the compiler to spot additional opportunities for simplification. One example of this in practice is the ability to convert a pair of CXs in opposite directions to just a single CX (along with an implicit SWAP that isn’t actually performed).</p>
 <div class="jupyter_cell jupyter_container docutils container">
 <div class="cell_input code_cell docutils container">
@@ -2935,7 +2935,7 @@ can support the full range of expressions and comparisons shown above.</p>
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#clifford-tableaux">Clifford Tableaux</a></li>
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#classical-and-conditional-operations">Classical and conditional operations</a></li>
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#circuit-level-operations">Circuit-Level Operations</a></li>
-<li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#id9">Implicit Qubit Permutations</a></li>
+<li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#implicit-qubit-permutations">Implicit Qubit Permutations</a></li>
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#modifying-operations-within-circuits">Modifying Operations Within Circuits</a></li>
 </ul>
 </li>

--- a/docs/manual/manual_circuit.html
+++ b/docs/manual/manual_circuit.html
@@ -364,7 +364,7 @@ document.write(`
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#symbolic-unitaries-and-states">Symbolic unitaries and states</a></li>
 </ul>
 </li>
-<li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#advanced-topics">Advanced Topics</a><ul class="nav section-nav flex-column">
+<li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#advanced-circuit-construction-topics">Advanced Circuit Construction Topics</a><ul class="nav section-nav flex-column">
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#custom-parameterised-gates">Custom parameterised Gates</a></li>
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#clifford-tableaux">Clifford Tableaux</a></li>
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#classical-and-conditional-operations">Classical and conditional operations</a></li>
@@ -976,7 +976,7 @@ X OpType.X [q[1]]
 
 
 
-    &lt;div id=&#34;circuit-display-vue-container-de71819a-3c3c-4835-b77f-4b8b819317af&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
+    &lt;div id=&#34;circuit-display-vue-container-574357e0-6d1c-4cec-bf8e-b85a1fd08649&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
         &lt;div style=&#34;display: none&#34;&gt;
             &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.3&#34;], &#34;type&#34;: &#34;Rx&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;CZ&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
         &lt;/div&gt;
@@ -986,7 +986,7 @@ X OpType.X [q[1]]
         &gt;&lt;/circuit-display-container&gt;
     &lt;/div&gt;
     &lt;script type=&#34;application/javascript&#34;&gt;
-      const circuitRendererUid = &#34;de71819a-3c3c-4835-b77f-4b8b819317af&#34;;
+      const circuitRendererUid = &#34;574357e0-6d1c-4cec-bf8e-b85a1fd08649&#34;;
       const displayOptions = JSON.parse(&#39;{}&#39;);
 
       // Script to initialise the circuit renderer app
@@ -1134,7 +1134,7 @@ Circuit depth = 3
 
 
 
-    &lt;div id=&#34;circuit-display-vue-container-f689b998-291c-45dd-9768-7e12b56d99ca&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
+    &lt;div id=&#34;circuit-display-vue-container-67f04ba0-db60-4c6c-bf15-9cbb9f0b9fb5&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
         &lt;div style=&#34;display: none&#34;&gt;
             &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;T&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;n_qb&#34;: 3, &#34;params&#34;: [&#34;0.6&#34;], &#34;type&#34;: &#34;CnRy&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CZ&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;T&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;CZ&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;T&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
         &lt;/div&gt;
@@ -1144,7 +1144,7 @@ Circuit depth = 3
         &gt;&lt;/circuit-display-container&gt;
     &lt;/div&gt;
     &lt;script type=&#34;application/javascript&#34;&gt;
-      const circuitRendererUid = &#34;f689b998-291c-45dd-9768-7e12b56d99ca&#34;;
+      const circuitRendererUid = &#34;67f04ba0-db60-4c6c-bf15-9cbb9f0b9fb5&#34;;
       const displayOptions = JSON.parse(&#39;{}&#39;);
 
       // Script to initialise the circuit renderer app
@@ -1243,7 +1243,7 @@ it to another circuit as part of a larger algorithm.</p>
 
 
 
-    &lt;div id=&#34;circuit-display-vue-container-b715c4d4-03dc-47ef-ba2c-a2b7ce28adc6&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
+    &lt;div id=&#34;circuit-display-vue-container-7cc86c47-f067-4071-8e28-46ff0ba27a79&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
         &lt;div style=&#34;display: none&#34;&gt;
             &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;n_qb&#34;: 3, &#34;type&#34;: &#34;CnZ&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;name&#34;: &#34;Oracle&#34;, &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
         &lt;/div&gt;
@@ -1253,7 +1253,7 @@ it to another circuit as part of a larger algorithm.</p>
         &gt;&lt;/circuit-display-container&gt;
     &lt;/div&gt;
     &lt;script type=&#34;application/javascript&#34;&gt;
-      const circuitRendererUid = &#34;b715c4d4-03dc-47ef-ba2c-a2b7ce28adc6&#34;;
+      const circuitRendererUid = &#34;7cc86c47-f067-4071-8e28-46ff0ba27a79&#34;;
       const displayOptions = JSON.parse(&#39;{}&#39;);
 
       // Script to initialise the circuit renderer app
@@ -1327,9 +1327,9 @@ window.pytketCircuitDisplays[circuitRendererUid] = app;
 
 
 
-    &lt;div id=&#34;circuit-display-vue-container-7374b8cc-01bd-4d14-85a4-e773d3e6bd54&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
+    &lt;div id=&#34;circuit-display-vue-container-fa23cee8-67ba-49a2-9e9a-0edfb0b8fe50&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
         &lt;div style=&#34;display: none&#34;&gt;
-            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;circuit&#34;: {&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;n_qb&#34;: 3, &#34;type&#34;: &#34;CnZ&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;name&#34;: &#34;Oracle&#34;, &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}, &#34;id&#34;: &#34;1b7f835e-ebca-4a7d-98c0-f6454d786c1a&#34;, &#34;type&#34;: &#34;CircBox&#34;}, &#34;type&#34;: &#34;CircBox&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
+            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;circuit&#34;: {&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;n_qb&#34;: 3, &#34;type&#34;: &#34;CnZ&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;name&#34;: &#34;Oracle&#34;, &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}, &#34;id&#34;: &#34;04565083-7e0b-4fb8-a341-5d9618820db5&#34;, &#34;type&#34;: &#34;CircBox&#34;}, &#34;type&#34;: &#34;CircBox&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
         &lt;/div&gt;
         &lt;circuit-display-container
                 :circuit-element-str=&#34;&#39;#circuit-json-to-display&#39;&#34;
@@ -1337,7 +1337,7 @@ window.pytketCircuitDisplays[circuitRendererUid] = app;
         &gt;&lt;/circuit-display-container&gt;
     &lt;/div&gt;
     &lt;script type=&#34;application/javascript&#34;&gt;
-      const circuitRendererUid = &#34;7374b8cc-01bd-4d14-85a4-e773d3e6bd54&#34;;
+      const circuitRendererUid = &#34;fa23cee8-67ba-49a2-9e9a-0edfb0b8fe50&#34;;
       const displayOptions = JSON.parse(&#39;{}&#39;);
 
       // Script to initialise the circuit renderer app
@@ -1545,7 +1545,7 @@ e^{-i \frac{\pi}{2} \theta P}\,, \quad P \in \{I, X, Y, Z\}^{\otimes n}
 
 
 
-    &lt;div id=&#34;circuit-display-vue-container-616c5898-84d9-4174-8309-974586b7f15e&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
+    &lt;div id=&#34;circuit-display-vue-container-c04bb022-ea05-46f0-993e-52680ea17740&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
         &lt;div style=&#34;display: none&#34;&gt;
             &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;V&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [3]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [3]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.7&#34;], &#34;type&#34;: &#34;Rz&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [3]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;Vdg&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [3]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]], [[&#34;q&#34;, [3]], [&#34;q&#34;, [3]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]], [&#34;q&#34;, [3]]]}&lt;/div&gt;
         &lt;/div&gt;
@@ -1555,7 +1555,7 @@ e^{-i \frac{\pi}{2} \theta P}\,, \quad P \in \{I, X, Y, Z\}^{\otimes n}
         &gt;&lt;/circuit-display-container&gt;
     &lt;/div&gt;
     &lt;script type=&#34;application/javascript&#34;&gt;
-      const circuitRendererUid = &#34;616c5898-84d9-4174-8309-974586b7f15e&#34;;
+      const circuitRendererUid = &#34;c04bb022-ea05-46f0-993e-52680ea17740&#34;;
       const displayOptions = JSON.parse(&#39;{}&#39;);
 
       // Script to initialise the circuit renderer app
@@ -1657,7 +1657,7 @@ C: |x\rangle \longmapsto e^{2\pi i p(x)}|g(x)\rangle
 
 
 
-    &lt;div id=&#34;circuit-display-vue-container-65312582-6a50-4760-9c22-fd45ac7acc3b&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
+    &lt;div id=&#34;circuit-display-vue-container-86840cf6-cf58-4b91-9187-1d4dc6a6ed3e&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
         &lt;div style=&#34;display: none&#34;&gt;
             &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;params&#34;: [&#34;1.05&#34;], &#34;type&#34;: &#34;Rz&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.05&#34;], &#34;type&#34;: &#34;Rz&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.333&#34;], &#34;type&#34;: &#34;Rz&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
         &lt;/div&gt;
@@ -1667,7 +1667,7 @@ C: |x\rangle \longmapsto e^{2\pi i p(x)}|g(x)\rangle
         &gt;&lt;/circuit-display-container&gt;
     &lt;/div&gt;
     &lt;script type=&#34;application/javascript&#34;&gt;
-      const circuitRendererUid = &#34;65312582-6a50-4760-9c22-fd45ac7acc3b&#34;;
+      const circuitRendererUid = &#34;86840cf6-cf58-4b91-9187-1d4dc6a6ed3e&#34;;
       const displayOptions = JSON.parse(&#39;{}&#39;);
 
       // Script to initialise the circuit renderer app
@@ -1760,9 +1760,9 @@ To create a multiplexor we simply construct a dictionary where the keys are the 
 
 
 
-    &lt;div id=&#34;circuit-display-vue-container-024cd44a-4693-4243-a1c1-82cf68290251&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
+    &lt;div id=&#34;circuit-display-vue-container-88323fbd-1b68-40ca-ac9b-7d8df49ad356&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
         &lt;div style=&#34;display: none&#34;&gt;
-            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;5eca2085-46de-4a71-87da-4108c3f8e050&#34;, &#34;op_map&#34;: [[[false, false], {&#34;params&#34;: [&#34;0.3&#34;], &#34;type&#34;: &#34;Rz&#34;}], [[true, true], {&#34;type&#34;: &#34;H&#34;}]], &#34;type&#34;: &#34;MultiplexorBox&#34;}, &#34;type&#34;: &#34;MultiplexorBox&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
+            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;b52bebcc-4f52-478a-a5c3-e7e44893b8f0&#34;, &#34;op_map&#34;: [[[false, false], {&#34;params&#34;: [&#34;0.3&#34;], &#34;type&#34;: &#34;Rz&#34;}], [[true, true], {&#34;type&#34;: &#34;H&#34;}]], &#34;type&#34;: &#34;MultiplexorBox&#34;}, &#34;type&#34;: &#34;MultiplexorBox&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
         &lt;/div&gt;
         &lt;circuit-display-container
                 :circuit-element-str=&#34;&#39;#circuit-json-to-display&#39;&#34;
@@ -1770,7 +1770,7 @@ To create a multiplexor we simply construct a dictionary where the keys are the 
         &gt;&lt;/circuit-display-container&gt;
     &lt;/div&gt;
     &lt;script type=&#34;application/javascript&#34;&gt;
-      const circuitRendererUid = &#34;024cd44a-4693-4243-a1c1-82cf68290251&#34;;
+      const circuitRendererUid = &#34;88323fbd-1b68-40ca-ac9b-7d8df49ad356&#34;;
       const displayOptions = JSON.parse(&#39;{}&#39;);
 
       // Script to initialise the circuit renderer app
@@ -1955,9 +1955,9 @@ In pytket however, the permutation is implemented efficently using a sequence of
 
 
 
-    &lt;div id=&#34;circuit-display-vue-container-863eb94f-7156-421f-9f7e-3fe986713b5e&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
+    &lt;div id=&#34;circuit-display-vue-container-684a7cfa-5375-4654-b8a7-e829656b42e1&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
         &lt;div style=&#34;display: none&#34;&gt;
-            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [2]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;bad777b6-8587-49fd-bd0d-5fddae650d7f&#34;, &#34;op_map&#34;: [[[false, true], {&#34;params&#34;: [&#34;1&#34;], &#34;type&#34;: &#34;Ry&#34;}]], &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}, &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [2]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;5e5125b0-8207-4a92-8aa9-0f64e6cd444f&#34;, &#34;op_map&#34;: [[[true, true], {&#34;params&#34;: [&#34;1&#34;], &#34;type&#34;: &#34;Ry&#34;}]], &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}, &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [2]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;b04e5ce7-6834-4fdf-b409-b7fdc1e1e79d&#34;, &#34;op_map&#34;: [[[false, false], {&#34;params&#34;: [&#34;1&#34;], &#34;type&#34;: &#34;Ry&#34;}], [[false, true], {&#34;params&#34;: [&#34;1&#34;], &#34;type&#34;: &#34;Ry&#34;}]], &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}, &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;diagonal&#34;: [[[-1.0, 0.0]], [[1.0, 0.0]], [[1.0, 0.0]], [[1.0, 0.0]], [[1.0, 0.0]], [[-1.0, 0.0]], [[1.0, 0.0]], [[1.0, 0.0]]], &#34;id&#34;: &#34;9366c398-5f4e-497e-9931-6db51eebb29a&#34;, &#34;type&#34;: &#34;DiagonalBox&#34;, &#34;upper_triangle&#34;: true}, &#34;type&#34;: &#34;DiagonalBox&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
+            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [2]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;de0ab917-59a6-4d49-9f8e-29cec1463b27&#34;, &#34;op_map&#34;: [[[false, true], {&#34;params&#34;: [&#34;1&#34;], &#34;type&#34;: &#34;Ry&#34;}]], &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}, &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [2]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;e01e9463-eba7-44ca-a576-8e3d08ed1170&#34;, &#34;op_map&#34;: [[[true, true], {&#34;params&#34;: [&#34;1&#34;], &#34;type&#34;: &#34;Ry&#34;}]], &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}, &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [2]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;7cea2061-7778-47bd-af9e-f4de1154146b&#34;, &#34;op_map&#34;: [[[false, false], {&#34;params&#34;: [&#34;1&#34;], &#34;type&#34;: &#34;Ry&#34;}], [[false, true], {&#34;params&#34;: [&#34;1&#34;], &#34;type&#34;: &#34;Ry&#34;}]], &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}, &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;diagonal&#34;: [[[-1.0, 0.0]], [[1.0, 0.0]], [[1.0, 0.0]], [[1.0, 0.0]], [[1.0, 0.0]], [[-1.0, 0.0]], [[1.0, 0.0]], [[1.0, 0.0]]], &#34;id&#34;: &#34;4de8f79a-bcd8-4642-a17b-efeaaebbb7ad&#34;, &#34;type&#34;: &#34;DiagonalBox&#34;, &#34;upper_triangle&#34;: true}, &#34;type&#34;: &#34;DiagonalBox&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
         &lt;/div&gt;
         &lt;circuit-display-container
                 :circuit-element-str=&#34;&#39;#circuit-json-to-display&#39;&#34;
@@ -1965,7 +1965,7 @@ In pytket however, the permutation is implemented efficently using a sequence of
         &gt;&lt;/circuit-display-container&gt;
     &lt;/div&gt;
     &lt;script type=&#34;application/javascript&#34;&gt;
-      const circuitRendererUid = &#34;863eb94f-7156-421f-9f7e-3fe986713b5e&#34;;
+      const circuitRendererUid = &#34;684a7cfa-5375-4654-b8a7-e829656b42e1&#34;;
       const displayOptions = JSON.parse(&#39;{}&#39;);
 
       // Script to initialise the circuit renderer app
@@ -2033,9 +2033,9 @@ window.pytketCircuitDisplays[circuitRendererUid] = app;
 
 
 
-    &lt;div id=&#34;circuit-display-vue-container-a5db4be2-72ed-40da-a510-a0ae236eb101&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
+    &lt;div id=&#34;circuit-display-vue-container-99789855-2ab7-4ee8-88bc-970e3671e34b&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
         &lt;div style=&#34;display: none&#34;&gt;
-            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;ce118aaf-40ef-470a-844b-dd6ad6c9af0d&#34;, &#34;is_inverse&#34;: false, &#34;statevector&#34;: [[[0.0, 0.0]], [[0.5773502691896258, 0.0]], [[0.5773502691896258, 0.0]], [[0.0, 0.0]], [[0.5773502691896258, 0.0]], [[0.0, 0.0]], [[0.0, 0.0]], [[0.0, 0.0]]], &#34;type&#34;: &#34;StatePreparationBox&#34;}, &#34;type&#34;: &#34;StatePreparationBox&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;58441fbd-2be8-491d-8b59-42134308d017&#34;, &#34;permutation&#34;: [[[false, false, false], [true, false, false]], [[false, false, true], [true, true, true]], [[true, false, false], [false, false, false]], [[true, true, true], [false, false, true]]], &#34;rotation_axis&#34;: &#34;Ry&#34;, &#34;type&#34;: &#34;ToffoliBox&#34;}, &#34;type&#34;: &#34;ToffoliBox&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
+            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;05ffdba6-43fd-4209-8779-fe51c7692b9f&#34;, &#34;is_inverse&#34;: false, &#34;statevector&#34;: [[[0.0, 0.0]], [[0.5773502691896258, 0.0]], [[0.5773502691896258, 0.0]], [[0.0, 0.0]], [[0.5773502691896258, 0.0]], [[0.0, 0.0]], [[0.0, 0.0]], [[0.0, 0.0]]], &#34;type&#34;: &#34;StatePreparationBox&#34;}, &#34;type&#34;: &#34;StatePreparationBox&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;9c27cd61-5da3-4de2-a770-e1b3e39819cd&#34;, &#34;permutation&#34;: [[[false, false, false], [true, false, false]], [[false, false, true], [true, true, true]], [[true, false, false], [false, false, false]], [[true, true, true], [false, false, true]]], &#34;rotation_axis&#34;: &#34;Ry&#34;, &#34;type&#34;: &#34;ToffoliBox&#34;}, &#34;type&#34;: &#34;ToffoliBox&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
         &lt;/div&gt;
         &lt;circuit-display-container
                 :circuit-element-str=&#34;&#39;#circuit-json-to-display&#39;&#34;
@@ -2043,7 +2043,7 @@ window.pytketCircuitDisplays[circuitRendererUid] = app;
         &gt;&lt;/circuit-display-container&gt;
     &lt;/div&gt;
     &lt;script type=&#34;application/javascript&#34;&gt;
-      const circuitRendererUid = &#34;a5db4be2-72ed-40da-a510-a0ae236eb101&#34;;
+      const circuitRendererUid = &#34;99789855-2ab7-4ee8-88bc-970e3671e34b&#34;;
       const displayOptions = JSON.parse(&#39;{}&#39;);
 
       // Script to initialise the circuit renderer app
@@ -2386,8 +2386,8 @@ The conversion functions use the <a class="reference external" href="https://doc
 </div>
 </section>
 </section>
-<section id="advanced-topics">
-<h2>Advanced Topics<a class="headerlink" href="#advanced-topics" title="Permalink to this heading">#</a></h2>
+<section id="advanced-circuit-construction-topics">
+<h2>Advanced Circuit Construction Topics<a class="headerlink" href="#advanced-circuit-construction-topics" title="Permalink to this heading">#</a></h2>
 <section id="custom-parameterised-gates">
 <h3>Custom parameterised Gates<a class="headerlink" href="#custom-parameterised-gates" title="Permalink to this heading">#</a></h3>
 <p>The <code class="xref py py-class docutils literal notranslate"><span class="pre">CircBox</span></code> construction is good for subroutines where the instruction sequence is fixed. The <code class="xref py py-class docutils literal notranslate"><span class="pre">CustomGateDef</span></code> construction generalises this to construct parameterised subroutines by binding symbols in the definition circuit and instantiating them at each instance. Any symbolic <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> can be provided as the subroutine definition. Remaining symbols that are not bound are treated as free symbols in the global scope.</p>
@@ -2930,7 +2930,7 @@ can support the full range of expressions and comparisons shown above.</p>
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#symbolic-unitaries-and-states">Symbolic unitaries and states</a></li>
 </ul>
 </li>
-<li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#advanced-topics">Advanced Topics</a><ul class="nav section-nav flex-column">
+<li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#advanced-circuit-construction-topics">Advanced Circuit Construction Topics</a><ul class="nav section-nav flex-column">
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#custom-parameterised-gates">Custom parameterised Gates</a></li>
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#clifford-tableaux">Clifford Tableaux</a></li>
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#classical-and-conditional-operations">Classical and conditional operations</a></li>

--- a/docs/manual/manual_circuit.html
+++ b/docs/manual/manual_circuit.html
@@ -976,7 +976,7 @@ X OpType.X [q[1]]
 
 
 
-    &lt;div id=&#34;circuit-display-vue-container-325e0a69-17da-405b-bfb9-093a726d4d97&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
+    &lt;div id=&#34;circuit-display-vue-container-d5512ccb-33c7-464e-afdb-b471c9be6bee&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
         &lt;div style=&#34;display: none&#34;&gt;
             &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.3&#34;], &#34;type&#34;: &#34;Rx&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;CZ&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
         &lt;/div&gt;
@@ -986,7 +986,7 @@ X OpType.X [q[1]]
         &gt;&lt;/circuit-display-container&gt;
     &lt;/div&gt;
     &lt;script type=&#34;application/javascript&#34;&gt;
-      const circuitRendererUid = &#34;325e0a69-17da-405b-bfb9-093a726d4d97&#34;;
+      const circuitRendererUid = &#34;d5512ccb-33c7-464e-afdb-b471c9be6bee&#34;;
       const displayOptions = JSON.parse(&#39;{}&#39;);
 
       // Script to initialise the circuit renderer app
@@ -1134,7 +1134,7 @@ Circuit depth = 3
 
 
 
-    &lt;div id=&#34;circuit-display-vue-container-881720da-e73d-4fdd-a921-65c5f51802f9&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
+    &lt;div id=&#34;circuit-display-vue-container-d5b6d47f-535e-40a6-98c6-15915f72ab6c&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
         &lt;div style=&#34;display: none&#34;&gt;
             &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;T&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;n_qb&#34;: 3, &#34;params&#34;: [&#34;0.6&#34;], &#34;type&#34;: &#34;CnRy&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CZ&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;T&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;CZ&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;T&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
         &lt;/div&gt;
@@ -1144,7 +1144,7 @@ Circuit depth = 3
         &gt;&lt;/circuit-display-container&gt;
     &lt;/div&gt;
     &lt;script type=&#34;application/javascript&#34;&gt;
-      const circuitRendererUid = &#34;881720da-e73d-4fdd-a921-65c5f51802f9&#34;;
+      const circuitRendererUid = &#34;d5b6d47f-535e-40a6-98c6-15915f72ab6c&#34;;
       const displayOptions = JSON.parse(&#39;{}&#39;);
 
       // Script to initialise the circuit renderer app
@@ -1243,7 +1243,7 @@ it to another circuit as part of a larger algorithm.</p>
 
 
 
-    &lt;div id=&#34;circuit-display-vue-container-9cb5fc2d-3a0d-46c0-af8b-64d23425a058&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
+    &lt;div id=&#34;circuit-display-vue-container-d3c06bd6-1c74-4b00-bfd1-16002620e5e8&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
         &lt;div style=&#34;display: none&#34;&gt;
             &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;n_qb&#34;: 3, &#34;type&#34;: &#34;CnZ&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;name&#34;: &#34;Oracle&#34;, &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
         &lt;/div&gt;
@@ -1253,7 +1253,7 @@ it to another circuit as part of a larger algorithm.</p>
         &gt;&lt;/circuit-display-container&gt;
     &lt;/div&gt;
     &lt;script type=&#34;application/javascript&#34;&gt;
-      const circuitRendererUid = &#34;9cb5fc2d-3a0d-46c0-af8b-64d23425a058&#34;;
+      const circuitRendererUid = &#34;d3c06bd6-1c74-4b00-bfd1-16002620e5e8&#34;;
       const displayOptions = JSON.parse(&#39;{}&#39;);
 
       // Script to initialise the circuit renderer app
@@ -1327,9 +1327,9 @@ window.pytketCircuitDisplays[circuitRendererUid] = app;
 
 
 
-    &lt;div id=&#34;circuit-display-vue-container-8edbd034-8f39-4fdf-b47b-977ba2ccd5ad&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
+    &lt;div id=&#34;circuit-display-vue-container-b960bb93-49d7-473a-8ea8-084ce12fd812&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
         &lt;div style=&#34;display: none&#34;&gt;
-            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;circuit&#34;: {&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;n_qb&#34;: 3, &#34;type&#34;: &#34;CnZ&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;name&#34;: &#34;Oracle&#34;, &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}, &#34;id&#34;: &#34;f6a9330c-47ee-4946-a7ec-75e17a39c901&#34;, &#34;type&#34;: &#34;CircBox&#34;}, &#34;type&#34;: &#34;CircBox&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
+            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;circuit&#34;: {&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;n_qb&#34;: 3, &#34;type&#34;: &#34;CnZ&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;name&#34;: &#34;Oracle&#34;, &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}, &#34;id&#34;: &#34;67750411-1709-4bf7-8dce-936aff87706d&#34;, &#34;type&#34;: &#34;CircBox&#34;}, &#34;type&#34;: &#34;CircBox&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
         &lt;/div&gt;
         &lt;circuit-display-container
                 :circuit-element-str=&#34;&#39;#circuit-json-to-display&#39;&#34;
@@ -1337,7 +1337,7 @@ window.pytketCircuitDisplays[circuitRendererUid] = app;
         &gt;&lt;/circuit-display-container&gt;
     &lt;/div&gt;
     &lt;script type=&#34;application/javascript&#34;&gt;
-      const circuitRendererUid = &#34;8edbd034-8f39-4fdf-b47b-977ba2ccd5ad&#34;;
+      const circuitRendererUid = &#34;b960bb93-49d7-473a-8ea8-084ce12fd812&#34;;
       const displayOptions = JSON.parse(&#39;{}&#39;);
 
       // Script to initialise the circuit renderer app
@@ -1545,7 +1545,7 @@ e^{-i \frac{\pi}{2} \theta P}\,, \quad P \in \{I, X, Y, Z\}^{\otimes n}
 
 
 
-    &lt;div id=&#34;circuit-display-vue-container-45b3580a-0420-4832-bc9b-5d276be81f4e&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
+    &lt;div id=&#34;circuit-display-vue-container-2088cbc3-f8f3-4896-8e86-8c3e1a32d004&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
         &lt;div style=&#34;display: none&#34;&gt;
             &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;V&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [3]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [3]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.7&#34;], &#34;type&#34;: &#34;Rz&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [3]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;Vdg&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [3]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]], [[&#34;q&#34;, [3]], [&#34;q&#34;, [3]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]], [&#34;q&#34;, [3]]]}&lt;/div&gt;
         &lt;/div&gt;
@@ -1555,7 +1555,7 @@ e^{-i \frac{\pi}{2} \theta P}\,, \quad P \in \{I, X, Y, Z\}^{\otimes n}
         &gt;&lt;/circuit-display-container&gt;
     &lt;/div&gt;
     &lt;script type=&#34;application/javascript&#34;&gt;
-      const circuitRendererUid = &#34;45b3580a-0420-4832-bc9b-5d276be81f4e&#34;;
+      const circuitRendererUid = &#34;2088cbc3-f8f3-4896-8e86-8c3e1a32d004&#34;;
       const displayOptions = JSON.parse(&#39;{}&#39;);
 
       // Script to initialise the circuit renderer app
@@ -1657,7 +1657,7 @@ C: |x\rangle \longmapsto e^{2\pi i p(x)}|g(x)\rangle
 
 
 
-    &lt;div id=&#34;circuit-display-vue-container-0a86774e-6efc-4850-a66d-38d9993f70e9&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
+    &lt;div id=&#34;circuit-display-vue-container-e3ec09eb-68a2-405f-b568-b1179a8ccbb2&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
         &lt;div style=&#34;display: none&#34;&gt;
             &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;params&#34;: [&#34;1.05&#34;], &#34;type&#34;: &#34;Rz&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.05&#34;], &#34;type&#34;: &#34;Rz&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.333&#34;], &#34;type&#34;: &#34;Rz&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
         &lt;/div&gt;
@@ -1667,7 +1667,7 @@ C: |x\rangle \longmapsto e^{2\pi i p(x)}|g(x)\rangle
         &gt;&lt;/circuit-display-container&gt;
     &lt;/div&gt;
     &lt;script type=&#34;application/javascript&#34;&gt;
-      const circuitRendererUid = &#34;0a86774e-6efc-4850-a66d-38d9993f70e9&#34;;
+      const circuitRendererUid = &#34;e3ec09eb-68a2-405f-b568-b1179a8ccbb2&#34;;
       const displayOptions = JSON.parse(&#39;{}&#39;);
 
       // Script to initialise the circuit renderer app
@@ -1760,9 +1760,9 @@ To create a multiplexor we simply construct a dictionary where the keys are the 
 
 
 
-    &lt;div id=&#34;circuit-display-vue-container-87034f20-d3c5-46d6-ba63-e8af8d814548&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
+    &lt;div id=&#34;circuit-display-vue-container-02b55e93-db90-4ec8-a308-7037d15ddc45&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
         &lt;div style=&#34;display: none&#34;&gt;
-            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;329e5415-f93d-4358-8d13-b33e1d0b9e66&#34;, &#34;op_map&#34;: [[[false, false], {&#34;params&#34;: [&#34;0.3&#34;], &#34;type&#34;: &#34;Rz&#34;}], [[true, true], {&#34;type&#34;: &#34;H&#34;}]], &#34;type&#34;: &#34;MultiplexorBox&#34;}, &#34;type&#34;: &#34;MultiplexorBox&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
+            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;81926e64-90fc-4c72-bf49-e066a162b4ed&#34;, &#34;op_map&#34;: [[[false, false], {&#34;params&#34;: [&#34;0.3&#34;], &#34;type&#34;: &#34;Rz&#34;}], [[true, true], {&#34;type&#34;: &#34;H&#34;}]], &#34;type&#34;: &#34;MultiplexorBox&#34;}, &#34;type&#34;: &#34;MultiplexorBox&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
         &lt;/div&gt;
         &lt;circuit-display-container
                 :circuit-element-str=&#34;&#39;#circuit-json-to-display&#39;&#34;
@@ -1770,7 +1770,7 @@ To create a multiplexor we simply construct a dictionary where the keys are the 
         &gt;&lt;/circuit-display-container&gt;
     &lt;/div&gt;
     &lt;script type=&#34;application/javascript&#34;&gt;
-      const circuitRendererUid = &#34;87034f20-d3c5-46d6-ba63-e8af8d814548&#34;;
+      const circuitRendererUid = &#34;02b55e93-db90-4ec8-a308-7037d15ddc45&#34;;
       const displayOptions = JSON.parse(&#39;{}&#39;);
 
       // Script to initialise the circuit renderer app
@@ -1955,9 +1955,9 @@ In pytket however, the permutation is implemented efficently using a sequence of
 
 
 
-    &lt;div id=&#34;circuit-display-vue-container-89be8080-e3f7-447e-8a61-5ae8b4580fa9&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
+    &lt;div id=&#34;circuit-display-vue-container-4b78b01a-ac64-425a-a76a-7e2eb8545bab&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
         &lt;div style=&#34;display: none&#34;&gt;
-            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [2]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;84210e89-3d5f-4afd-a395-b8e4bb0bdc8a&#34;, &#34;op_map&#34;: [[[false, true], {&#34;params&#34;: [&#34;1&#34;], &#34;type&#34;: &#34;Ry&#34;}]], &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}, &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [2]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;a54c98bb-1e0c-4525-af2f-15166b287dc2&#34;, &#34;op_map&#34;: [[[true, true], {&#34;params&#34;: [&#34;1&#34;], &#34;type&#34;: &#34;Ry&#34;}]], &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}, &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [2]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;adc51354-6cab-48a2-a4a3-57710d2d9151&#34;, &#34;op_map&#34;: [[[false, false], {&#34;params&#34;: [&#34;1&#34;], &#34;type&#34;: &#34;Ry&#34;}], [[false, true], {&#34;params&#34;: [&#34;1&#34;], &#34;type&#34;: &#34;Ry&#34;}]], &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}, &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;diagonal&#34;: [[[-1.0, 0.0]], [[1.0, 0.0]], [[1.0, 0.0]], [[1.0, 0.0]], [[1.0, 0.0]], [[-1.0, 0.0]], [[1.0, 0.0]], [[1.0, 0.0]]], &#34;id&#34;: &#34;52e136f6-b911-4073-adbd-28ddcd455029&#34;, &#34;type&#34;: &#34;DiagonalBox&#34;, &#34;upper_triangle&#34;: true}, &#34;type&#34;: &#34;DiagonalBox&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
+            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [2]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;c63bc2b1-026c-43cb-9687-bc27d4c52726&#34;, &#34;op_map&#34;: [[[false, true], {&#34;params&#34;: [&#34;1&#34;], &#34;type&#34;: &#34;Ry&#34;}]], &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}, &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [2]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;48d57f2e-0694-489e-a7d7-09479c80e051&#34;, &#34;op_map&#34;: [[[true, true], {&#34;params&#34;: [&#34;1&#34;], &#34;type&#34;: &#34;Ry&#34;}]], &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}, &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [2]], [&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;ddea3a65-eeb6-4706-830f-96a2c28303f7&#34;, &#34;op_map&#34;: [[[false, false], {&#34;params&#34;: [&#34;1&#34;], &#34;type&#34;: &#34;Ry&#34;}], [[false, true], {&#34;params&#34;: [&#34;1&#34;], &#34;type&#34;: &#34;Ry&#34;}]], &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}, &#34;type&#34;: &#34;MultiplexedRotationBox&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;diagonal&#34;: [[[-1.0, 0.0]], [[1.0, 0.0]], [[1.0, 0.0]], [[1.0, 0.0]], [[1.0, 0.0]], [[-1.0, 0.0]], [[1.0, 0.0]], [[1.0, 0.0]]], &#34;id&#34;: &#34;41562ba1-03ca-4155-9876-5cd9bec9ccc0&#34;, &#34;type&#34;: &#34;DiagonalBox&#34;, &#34;upper_triangle&#34;: true}, &#34;type&#34;: &#34;DiagonalBox&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
         &lt;/div&gt;
         &lt;circuit-display-container
                 :circuit-element-str=&#34;&#39;#circuit-json-to-display&#39;&#34;
@@ -1965,7 +1965,7 @@ In pytket however, the permutation is implemented efficently using a sequence of
         &gt;&lt;/circuit-display-container&gt;
     &lt;/div&gt;
     &lt;script type=&#34;application/javascript&#34;&gt;
-      const circuitRendererUid = &#34;89be8080-e3f7-447e-8a61-5ae8b4580fa9&#34;;
+      const circuitRendererUid = &#34;4b78b01a-ac64-425a-a76a-7e2eb8545bab&#34;;
       const displayOptions = JSON.parse(&#39;{}&#39;);
 
       // Script to initialise the circuit renderer app
@@ -2033,9 +2033,9 @@ window.pytketCircuitDisplays[circuitRendererUid] = app;
 
 
 
-    &lt;div id=&#34;circuit-display-vue-container-c41a8ba7-2605-4d5b-88e9-0e96514f15fd&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
+    &lt;div id=&#34;circuit-display-vue-container-3f44d1aa-e0f9-4e94-9d35-5c2ac54142dc&#34; class=&#34;pytket-circuit-display-container&#34;&gt;
         &lt;div style=&#34;display: none&#34;&gt;
-            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;899365bb-5a6e-46c6-9bcf-227f677442cd&#34;, &#34;is_inverse&#34;: false, &#34;statevector&#34;: [[[0.0, 0.0]], [[0.5773502691896258, 0.0]], [[0.5773502691896258, 0.0]], [[0.0, 0.0]], [[0.5773502691896258, 0.0]], [[0.0, 0.0]], [[0.0, 0.0]], [[0.0, 0.0]]], &#34;type&#34;: &#34;StatePreparationBox&#34;}, &#34;type&#34;: &#34;StatePreparationBox&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;009d19a5-8ddd-4f2e-931b-df88435e3f18&#34;, &#34;permutation&#34;: [[[false, false, false], [true, false, false]], [[false, false, true], [true, true, true]], [[true, false, false], [false, false, false]], [[true, true, true], [false, false, true]]], &#34;rotation_axis&#34;: &#34;Ry&#34;, &#34;type&#34;: &#34;ToffoliBox&#34;}, &#34;type&#34;: &#34;ToffoliBox&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
+            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;d04c1dcd-21a7-4f62-bb54-6e114cc063b4&#34;, &#34;is_inverse&#34;: false, &#34;statevector&#34;: [[[0.0, 0.0]], [[0.5773502691896258, 0.0]], [[0.5773502691896258, 0.0]], [[0.0, 0.0]], [[0.5773502691896258, 0.0]], [[0.0, 0.0]], [[0.0, 0.0]], [[0.0, 0.0]]], &#34;type&#34;: &#34;StatePreparationBox&#34;}, &#34;type&#34;: &#34;StatePreparationBox&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;67c66fe9-1a7c-4a4b-a550-debb9f6a7184&#34;, &#34;permutation&#34;: [[[false, false, false], [true, false, false]], [[false, false, true], [true, true, true]], [[true, false, false], [false, false, false]], [[true, true, true], [false, false, true]]], &#34;rotation_axis&#34;: &#34;Ry&#34;, &#34;type&#34;: &#34;ToffoliBox&#34;}, &#34;type&#34;: &#34;ToffoliBox&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;
         &lt;/div&gt;
         &lt;circuit-display-container
                 :circuit-element-str=&#34;&#39;#circuit-json-to-display&#39;&#34;
@@ -2043,7 +2043,7 @@ window.pytketCircuitDisplays[circuitRendererUid] = app;
         &gt;&lt;/circuit-display-container&gt;
     &lt;/div&gt;
     &lt;script type=&#34;application/javascript&#34;&gt;
-      const circuitRendererUid = &#34;c41a8ba7-2605-4d5b-88e9-0e96514f15fd&#34;;
+      const circuitRendererUid = &#34;3f44d1aa-e0f9-4e94-9d35-5c2ac54142dc&#34;;
       const displayOptions = JSON.parse(&#39;{}&#39;);
 
       // Script to initialise the circuit renderer app
@@ -2175,7 +2175,7 @@ measure q[1] -&gt; c[1];
 </div>
 <div class="admonition note">
 <p class="admonition-title">Note</p>
-<p>The OpenQASM converters do not support circuits with <a class="reference external" href="https://cqcl.github.io/pytket/manual/manual_circuit.html#implicit-qubit-permutations">implicit qubit permutations</a> . This means that if a circuit contains such a permutation it will be ignored when exported to OpenQASM format.</p>
+<p>The OpenQASM converters do not support circuits with <a class="reference external" href="https://cqcl.github.io/pytket/manual/manual_circuit.html#id9">implicit qubit permutations</a> . This means that if a circuit contains such a permutation it will be ignored when exported to OpenQASM format.</p>
 </div>
 <p>The core <code class="docutils literal notranslate"><span class="pre">pytket</span></code> package additionally features a converter from Quipper, another circuit description language.</p>
 <div class="jupyter_cell jupyter_container docutils container">

--- a/docs/manual/manual_compiler.html
+++ b/docs/manual/manual_compiler.html
@@ -354,7 +354,7 @@ document.write(`
 <li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#predefined-sequences">Predefined Sequences</a></li>
 <li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#guidance-for-combining-passes">Guidance for Combining Passes</a></li>
 <li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#initial-and-final-maps">Initial and Final Maps</a></li>
-<li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#advanced-topics">Advanced Topics</a><ul class="nav section-nav flex-column">
+<li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#advanced-compilation-topics">Advanced Compilation Topics</a><ul class="nav section-nav flex-column">
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#compiling-symbolic-circuits">Compiling Symbolic Circuits</a></li>
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#user-defined-passes">User-defined Passes</a></li>
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#partial-compilation">Partial Compilation</a></li>
@@ -1214,8 +1214,8 @@ The single-qubit gates in our circuit also need to be decomposed into the IBM ga
 <p>No passes currently rename or swap classical data, but the classical bits are included in these maps for completeness.</p>
 </div>
 </section>
-<section id="advanced-topics">
-<h2>Advanced Topics<a class="headerlink" href="#advanced-topics" title="Permalink to this heading">#</a></h2>
+<section id="advanced-compilation-topics">
+<h2>Advanced Compilation Topics<a class="headerlink" href="#advanced-compilation-topics" title="Permalink to this heading">#</a></h2>
 <section id="compiling-symbolic-circuits">
 <h3>Compiling Symbolic Circuits<a class="headerlink" href="#compiling-symbolic-circuits" title="Permalink to this heading">#</a></h3>
 <p>For variational algorithms, the prominent benefit of defining a <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> symbolically and only instantiating it with concrete values when needed is that the compilation procedure would only need to be performed once. By saving time here we can cut down the overall time for an experiment; we could invest the time saved into applying more expensive optimisations on the <code class="xref py py-class docutils literal notranslate"><span class="pre">Circuit</span></code> to reduce the impact of noise further.</p>
@@ -1651,16 +1651,16 @@ the main circuit and the postprocessing circuit, returning both.</p>
 </div>
 </div>
 <div class="cell_output docutils container">
-<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>[[1 1]
+<div class="output stream highlight-none notranslate"><div class="highlight"><pre><span></span>[[0 0]
  [1 1]
- [1 1]
- [0 0]
- [1 1]
- [0 0]
  [0 0]
  [1 1]
  [0 0]
- [1 1]]
+ [0 0]
+ [1 1]
+ [0 0]
+ [1 1]
+ [0 0]]
 </pre></div>
 </div>
 </div>
@@ -1735,7 +1735,7 @@ noise.</p>
 <li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#predefined-sequences">Predefined Sequences</a></li>
 <li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#guidance-for-combining-passes">Guidance for Combining Passes</a></li>
 <li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#initial-and-final-maps">Initial and Final Maps</a></li>
-<li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#advanced-topics">Advanced Topics</a><ul class="nav section-nav flex-column">
+<li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#advanced-compilation-topics">Advanced Compilation Topics</a><ul class="nav section-nav flex-column">
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#compiling-symbolic-circuits">Compiling Symbolic Circuits</a></li>
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#user-defined-passes">User-defined Passes</a></li>
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#partial-compilation">Partial Compilation</a></li>

--- a/manual/conf.py
+++ b/manual/conf.py
@@ -13,6 +13,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "jupyter_sphinx",
     "sphinx_copybutton",
+    "sphinx.ext.autosectionlabel"
 ]
 
 html_theme = "sphinx_book_theme"

--- a/manual/manual_backend.rst
+++ b/manual/manual_backend.rst
@@ -134,8 +134,8 @@ If we don't care about the temporal order of the shots, we can instead retrieve 
 
 .. note:: :py:meth:`Backend.process_circuit` returns a handle to the computation to perform the quantum computation asynchronously. Non-blocking operations are essential when running circuits on remote devices, as submission and queuing times can be long. The handle may then be used to retrieve the results with :py:meth:`Backend.get_result`. If asynchronous computation is not needed, for example when running on a local simulator, pytket provides the shortcut `Backend.run_circuit` that will immediately execute the circuit and return a :py:class:`BackendResult`.
 
-Statevectors and Unitaries
---------------------------
+Statevector and Unitary Simulation with TKET Backends
+-----------------------------------------------------
 
 .. Any form of sampling introduces non-deterministic error, so for better accuracy we will want the exact state of the physical system; some simulators will provide direct access to this
 .. `get_state` gives full representation of that system's state in the 2^n-dimensional complex Hilbert space
@@ -564,8 +564,8 @@ Below we show how the :py:class:`CirqStateSampleBackend` from the ``pytket-cirq`
 .. Goals of the assistant
 .. How to set up and push/pull results
 
-Advanced Topics
----------------
+Advanced Backend Topics
+-----------------------
 
 Simulator Support for Expectation Values
 ========================================

--- a/manual/manual_circuit.rst
+++ b/manual/manual_circuit.rst
@@ -1149,8 +1149,8 @@ The conversion functions use the `sympy Quantum Mechanics module <https://docs.s
 .. warning::
     Unitaries corresponding to circuits with :math:`n` qubits have dimensions :math:`2^n \times 2^n`, so are computationally very expensive to calculate. Symbolic calculation is also computationally costly, meaning calculation of symbolic unitaries is only really feasible for very small circuits (of up to a few qubits in size). These utilities are provided as way to test the design of small subcircuits to check they are performing the intended unitary. Note also that as mentioned above, compilation of a symbolic circuit can generate long symbolic expressions; converting these circuits to a symbolic unitary could then result in a matrix object that is very hard to work with or interpret.
 
-Advanced Topics
----------------
+Advanced Circuit Construction Topics
+------------------------------------
 
 Custom parameterised Gates
 ==========================

--- a/manual/manual_circuit.rst
+++ b/manual/manual_circuit.rst
@@ -985,7 +985,7 @@ Though less expressive than native dictionary serialization, it is widely suppor
 
 .. Quipper
 
-.. note:: The OpenQASM converters do not support circuits with `implicit qubit permutations <https://cqcl.github.io/pytket/manual/manual_circuit.html#implicit-qubit-permutations>`_ . This means that if a circuit contains such a permutation it will be ignored when exported to OpenQASM format.
+.. note:: The OpenQASM converters do not support circuits with `implicit qubit permutations <https://cqcl.github.io/pytket/manual/manual_circuit.html#id9>`_ . This means that if a circuit contains such a permutation it will be ignored when exported to OpenQASM format.
 
 The core ``pytket`` package additionally features a converter from Quipper, another circuit description language.
 

--- a/manual/manual_circuit.rst
+++ b/manual/manual_circuit.rst
@@ -985,7 +985,7 @@ Though less expressive than native dictionary serialization, it is widely suppor
 
 .. Quipper
 
-.. note:: The OpenQASM converters do not support circuits with `implicit qubit permutations <https://cqcl.github.io/pytket/manual/manual_circuit.html#id9>`_ . This means that if a circuit contains such a permutation it will be ignored when exported to OpenQASM format.
+.. note:: The OpenQASM converters do not support circuits with :ref:`implicit qubit permutations <Implicit Qubit Permutations>`. This means that if a circuit contains such a permutation it will be ignored when exported to OpenQASM format.
 
 The core ``pytket`` package additionally features a converter from Quipper, another circuit description language.
 

--- a/manual/manual_compiler.rst
+++ b/manual/manual_compiler.rst
@@ -765,8 +765,8 @@ We can wrap up a :py:class:`Circuit` in a :py:class:`CompilationUnit` to allow u
 
 .. note:: No passes currently rename or swap classical data, but the classical bits are included in these maps for completeness.
 
-Advanced Topics
----------------
+Advanced Compilation Topics
+---------------------------
 
 Compiling Symbolic Circuits
 ===========================


### PR DESCRIPTION
Small PR to fix the two broken svg images in the circuit section of the manual.

<img width="808" alt="Screenshot 2023-05-26 at 17 52 38" src="https://github.com/CQCL/pytket/assets/93673602/fed5e6ab-fbdd-42ca-a23d-e22497b942cb">


I think there was some caching problem when I pushed the built html in https://github.com/CQCL/pytket/pull/236

I've rebuilt the html and it looks fine.

EDIT: I've also made use of the `sphinx.ext.autosectionlabel` to link to section headings. This then raised warnings about some duplicate headings we have e.g. "advanced topics". I have now modified these headings to remove these warnings

