### PR TITLE
don't execute qujax classification example

### DIFF
--- a/examples/_config.yml
+++ b/examples/_config.yml
@@ -10,7 +10,7 @@ sphinx:
 
 execute:
   # Exclude some examples from execution (these are still deployed as html pages)
-  exclude_patterns: [".venv/*", "Forest_portability_example.ipynb", "backends_example.ipynb", "qiskit_integration.ipynb", "comparing_simulators.ipynb", "expectation_value_example.ipynb", "pytket-qujax_heisenberg_vqe.ipynb", "spam_example.ipynb", "tket_benchmarking.ipynb", "entanglement_swapping.ipynb"]
+  exclude_patterns: [".venv/*", "Forest_portability_example.ipynb", "backends_example.ipynb", "qiskit_integration.ipynb", "comparing_simulators.ipynb", "expectation_value_example.ipynb", "pytket-qujax_heisenberg_vqe.ipynb", "spam_example.ipynb", "tket_benchmarking.ipynb", "entanglement_swapping.ipynb", "pytket-qujax-classification.ipynb"]
   timeout: 90    # The maximum time (in seconds) each notebook cell is allowed to run.
 
 # Information about where the book exists on the web

--- a/examples/_toc.yml
+++ b/examples/_toc.yml
@@ -16,13 +16,13 @@ chapters:
 - file: symbolics_example
 - file: ucc_vqe
 - file: pytket-qujax_qaoa
-- file: pytket-qujax-classification
 - file: benchmarking/README
 # The following notebooks are not executed
 - file: backends_example
 - file: comparing_simulators
 - file: qiskit_integration
 - file: Forest_portability_example
+- file: pytket-qujax-classification
 - file: expectation_value_example
 - file: entanglement_swapping
 - file: pytket-qujax_heisenberg_vqe


### PR DESCRIPTION
Removing a single notebook from execution as it seems to time out unpredictably causing issues with the build.