### PR TITLE
Update build_jupyterbook.yml

### DIFF
--- a/.github/workflows/build_jupyterbook.yml
+++ b/.github/workflows/build_jupyterbook.yml
@@ -36,6 +36,6 @@ jobs:
     - name: Build the book
       run: |
         cd examples
-        jupyter-book build -W --verbose .
+        jupyter-book build -W .
 
     # Only the build is tested on CI in the pytket repository. The built pages are deployed from the tket-site repository.

--- a/.github/workflows/build_jupyterbook.yml
+++ b/.github/workflows/build_jupyterbook.yml
@@ -32,6 +32,7 @@ jobs:
         python -m pip install jupyter-book
 
     # Build the book ensuring that build fails for warnings (-W flag)
+    # CLI Reference: https://jupyterbook.org/en/stable/reference/cli.html
     - name: Build the book
       run: |
         cd examples

--- a/.github/workflows/build_jupyterbook.yml
+++ b/.github/workflows/build_jupyterbook.yml
@@ -35,6 +35,6 @@ jobs:
     - name: Build the book
       run: |
         cd examples
-        jupyter-book build -W .
+        jupyter-book build -W --verbose .
 
     # Only the build is tested on CI in the pytket repository. The built pages are deployed from the tket-site repository.

--- a/.github/workflows/build_jupyterbook.yml
+++ b/.github/workflows/build_jupyterbook.yml
@@ -31,7 +31,7 @@ jobs:
         python -m pip install -r example_requirements.txt
         python -m pip install jupyter-book
 
-    # Build the book ensuring that build fails for warnings (-W flag)
+    # Build the book ensuring that the build treats warnings as errors (-W flag)
     # CLI Reference: https://jupyterbook.org/en/stable/reference/cli.html
     - name: Build the book
       run: |

--- a/.github/workflows/build_jupyterbook.yml
+++ b/.github/workflows/build_jupyterbook.yml
@@ -11,9 +11,9 @@ on:
     branches:
     - main
 
-# This job installs dependencies, build the book, and pushes it to `gh-pages`
+# This job installs dependencies and builds the jupyterbook
 jobs:
-  deploy-book:
+  check-jupyterbook-build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/examples/_config.yml
+++ b/examples/_config.yml
@@ -16,7 +16,7 @@ execute:
 
 # Information about where the book exists on the web
 repository:
-  url: https://github.com/CQCL/pytket/blob/main/examples/  # Location of notebook source files
+  url: https://github.com/CQCL/pytket  # notebook files located in pytket/examples
   path_to_book: docs  # Optional path to your book, relative to the repository root
   branch: master  # Which branch of the repository should be used when creating links (optional)
 

--- a/examples/_config.yml
+++ b/examples/_config.yml
@@ -16,7 +16,7 @@ execute:
 
 # Information about where the book exists on the web
 repository:
-  url: https://github.com/CQCL/pytket  # notebook files located in pytket/examples
+  url: https://github.com/CQCL/pytket  # Notebook files are located in pytket/examples
   path_to_book: docs  # Optional path to your book, relative to the repository root
   branch: master  # Which branch of the repository should be used when creating links (optional)
 


### PR DESCRIPTION
The name of the workflow is no longer accurate so I've changed the name and updated a comment.

I've also added the [verbose flag](https://jupyterbook.org/en/stable/reference/cli.html#cmdoption-jupyter-book-build-v) so hopefully we can get more information on CI failures.

Finally I've changed the github link back as it needs to be a repository and not a subdirectory.