### PR TITLE
temporarily exclude QPE notebook

### DIFF
--- a/examples/_config.yml
+++ b/examples/_config.yml
@@ -11,7 +11,7 @@ sphinx:
 
 execute:
   # Exclude some examples from execution (these are still deployed as html pages)
-  exclude_patterns: [".venv/*", "Forest_portability_example.ipynb", "backends_example.ipynb", "qiskit_integration.ipynb", "comparing_simulators.ipynb", "expectation_value_example.ipynb", "pytket-qujax_heisenberg_vqe.ipynb", "spam_example.ipynb", "tket_benchmarking.ipynb", "entanglement_swapping.ipynb", "pytket-qujax-classification.ipynb"]
+  exclude_patterns: [".venv/*", "Boxes_QPE_example.ipynb", "Forest_portability_example.ipynb", "backends_example.ipynb", "qiskit_integration.ipynb", "comparing_simulators.ipynb", "expectation_value_example.ipynb", "pytket-qujax_heisenberg_vqe.ipynb", "spam_example.ipynb", "tket_benchmarking.ipynb", "entanglement_swapping.ipynb", "pytket-qujax-classification.ipynb"]
   timeout: 90    # The maximum time (in seconds) each notebook cell is allowed to run.
 
 # Information about where the book exists on the web


### PR DESCRIPTION
This is a temporary workaround to try and stop the CI failures here 

I'm having trouble pulling the latest commits on the `example/QPE` branch for [this PR](https://github.com/CQCL/pytket/pull/241/).

Not sure how else to resolve the issue.