### PR TITLE
Fix requirements shown in manual index page

### DIFF
--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -372,12 +372,11 @@ document.write(`
   <section id="pytket-user-manual">
 <h1>Pytket User Manual<a class="headerlink" href="#pytket-user-manual" title="Permalink to this heading">#</a></h1>
 <p>This manual refers to the following versions of pytket and extensions:</p>
-<div class="highlight-text notranslate"><div class="highlight"><pre><span></span>
+<div class="highlight-text notranslate"><div class="highlight"><pre><span></span>pytket[ZX] == 1.21.0
+pytket-qiskit == 0.45.0
+pytket-cirq == 0.31.0
 </pre></div>
 </div>
-<p>pytket[ZX] == 1.21.0
-pytket-qiskit == 0.45.0
-pytket-cirq == 0.31.0</p>
 <div class="toctree-wrapper compound">
 <p aria-level="2" class="caption" role="heading"><span class="caption-text">Manual Sections:</span></p>
 <ul>


### PR DESCRIPTION
After https://github.com/CQCL/pytket/pull/264 the formatting of the manual index page was messed up.

This is because I did not push the html page after addressing the requested changes to the requirements file.

It now looks like this locally.

<img width="538" alt="Screenshot 2023-10-24 at 11 47 59" src="https://github.com/CQCL/pytket/assets/93673602/3863a7fa-9c1a-436e-ac8d-866922cec740">

I've added the built html page. This sort of thing should never happen once the manual is built on CI.