### PR TITLE
Update README and add `docs/manual` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ manual/build
 manual/jupyter_execute
 examples/_build/
 *.ipynb_checkpoints
+docs/manual

--- a/manual/README.md
+++ b/manual/README.md
@@ -10,7 +10,7 @@ First clone the pytket repository
 git clone git@github.com:CQCL/pytket.git
 ```
 
-It is recommended to set up a virtual environment in the pytket repository to manage dependencies.
+It is recommended to set up a virtual environment in the pytket repository to manage dependencies. 
 
 Once the virtual environment is set up we can run the `build-manual` script from the pytket directory which installs the necessary python packages and builds the html pages.
 
@@ -18,10 +18,8 @@ Once the virtual environment is set up we can run the `build-manual` script from
 ./build-manual
 ```
 
-Now the built html pages will appear in the local `docs/manual` directory. Its recommended to view the html pages locally after making changes to the source files.
+Now the built html pages will appear in the local `docs/manual` directory.
 
-If you want to make changes to the manual then you can commit changes to the source files on a local branch. Note that due to a current limitation of the manual build you will need to also commit changes to the built html file.
+If you are making changes to the manual then it is recommended to build the manual locally check the built html pages. If there are no issues commit your change to a local branch and make a pull request.
 
-For example if edits were made to `manual_backend.rst`. The html file `manual_backend.html` will also need to be added to the pull request as well.
-
-Note that the entire `docs/manual` directory gets deployed whenever a pull request is merged. The changes made in the pull request should show up in the github pages site as soon as the workflow run finishes.
+The manual contains many `jupyter-execute::` directives that run python code when the html is built. The manual build is also run on CI whenever changes are pushed to the pytket repository. If there is are any code snippets that give errors or warnings then the CI build will fail.

--- a/manual/README.md
+++ b/manual/README.md
@@ -10,7 +10,7 @@ First clone the pytket repository
 git clone git@github.com:CQCL/pytket.git
 ```
 
-It is recommended to set up a virtual environment in the pytket repository to manage dependencies. 
+It is recommended to set up a virtual environment in the pytket repository to manage dependencies.
 
 Once the virtual environment is set up we can run the `build-manual` script from the pytket directory which installs the necessary python packages and builds the html pages.
 

--- a/manual/README.md
+++ b/manual/README.md
@@ -20,6 +20,6 @@ Once the virtual environment is set up we can run the `build-manual` script from
 
 Now the built html pages will appear in the local `docs/manual` directory.
 
-If you are making changes to the manual then it is recommended to build the manual locally check the built html pages. If there are no issues commit your change to a local branch and make a pull request.
-
 The manual contains many `jupyter-execute::` directives that run python code when the html is built. The manual build is also run on CI whenever changes are pushed to the pytket repository. If there is are any code snippets that give errors or warnings then the CI build will fail.
+
+If you are making changes to the manual then it is recommended to build the manual locally check the built html pages. If there are no issues then you can commit your change to a local branch and make a pull request.


### PR DESCRIPTION
Updating the README after the changes made in https://github.com/CQCL/pytket/pull/268.

I've also added the `docs/manual` directory to `.gitignore`. This avoids cluttering source control when building the manual locally. 