### PR TITLE
Install `ipykernel` in docs build and remove duplication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ manual/build
 manual/jupyter_execute
 examples/_build/
 *.ipynb_checkpoints
-docs/manual

--- a/build-manual
+++ b/build-manual
@@ -3,6 +3,7 @@
 python -m pip install -r manual_requirements.txt
 python -m pip install sphinx sphinx-book-theme sphinx-copybutton jupyter-sphinx
 python -m pip install qiskit-algorithms
+python -m pip install ipykernel
 
 cd manual/
 
@@ -13,8 +14,3 @@ rm -rf build/
 sphinx-build -b html . build -W
 
 rm index.rst
-
-cd ..
-
-rm -rf docs/manual/
-cp -r manual/build/ docs/manual

--- a/manual/README.md
+++ b/manual/README.md
@@ -18,7 +18,7 @@ Once the virtual environment is set up we can run the `build-manual` script from
 ./build-manual
 ```
 
-Now the built html pages will appear in the local `docs/manual` directory.
+Now the built html pages will appear in the local `manual/build` directory.
 
 The manual contains many `jupyter-execute::` directives that run python code when the html is built. The manual build is also run on CI whenever changes are pushed to the pytket repository. If there is are any code snippets that give errors or warnings then the CI build will fail.
 


### PR DESCRIPTION
Follows some discussion in #272 

**Changes**

1. Installs `ipykernel` in `build-manual` script.

2. Removed the copying of the `manual/build` directory into the `docs/manual` directory. I've also removed the `docs/manual` from `.gitignore`.

**A question**

Wouldn't it be simpler if the `check-manual` workflow used the `build-manual` script directly? We have essentially the same build commands in multiple places.