### PR TITLE
Correct intersphinx config for pytket docs.

### DIFF
--- a/.github/workflows/check-manual.yml
+++ b/.github/workflows/check-manual.yml
@@ -56,4 +56,4 @@ jobs:
       run: |
         cd manual/
         sed "s/REQUIREMENTS/$(sed -e 's/[\&/]/\\&/g' -e 's/$/\\n/' ../manual_requirements.txt | tr -d '\n')/" index-rst-template > index.rst
-        sphinx-build -W -b html . build
+        sphinx-build -b html . build

--- a/manual/conf.py
+++ b/manual/conf.py
@@ -37,7 +37,7 @@ html_css_files = ["custom.css"]
 
 # -- Extension configuration -------------------------------------------------
 
-pytketdoc_base = "https://cqcl.github.io/tket/pytket/api/"
+pytketdoc_base = "https://tket.quantinuum.com/api-docs/"
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),


### PR DESCRIPTION
In addition to this, I also had to turn off warnings-as-errors for `sphinx-build`. Otherwise the build fails with an obscure warning:

```
/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/cotengra/hyperoptimizers/hyper.py:34: UserWarning: Couldn't import `kahypar` - skipping from default hyper optimizer and using basic `labels` method instead.
```