### PR TITLE
add TKET website links to examples TOC

### DIFF
--- a/examples/_toc.yml
+++ b/examples/_toc.yml
@@ -4,6 +4,18 @@
 format: jb-book
 root: Getting_started
 parts:
+  - caption: pytket documentation
+    chapters:
+    - url: https://tket.quantinuum.com/api-docs/
+      title: pytket API docs
+    - url: pytket extensions <https://tket.quantinuum.com/api-docs/extensions.html> 
+      title: pytket extensions
+    - url: https://tket.quantinuum.com/user-manual
+      title: Manual
+    - url: Example notebooks <https://tket.quantinuum.com/examples>
+      title: Example notebooks
+    - url: https://tket.quantinuum.com/
+      title: TKET website
   - caption: Building Quantum Circuits
     chapters:
     - file: circuit_generation_example


### PR DESCRIPTION
# Description

Adding links to the various other TKET documentation pages so that they are easier to find from the examples repository.
