### PR TITLE
fix: use raw string in CircBox name to avoid \d escape sequence

### DIFF
--- a/sphinx/examples/algorithms_and_protocols/phase_estimation.ipynb
+++ b/sphinx/examples/algorithms_and_protocols/phase_estimation.ipynb
@@ -146,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -222,7 +222,7 @@
    "source": [
     "inv_qft4_box = qft4_box.dagger\n",
     "# Explicitly set the name of the `CircBox` to $$QFT^\\dagger$$\n",
-    "inv_qft4_box.circuit_name = \"$$QFT^\\dagger$$\"\n",
+    "inv_qft4_box.circuit_name = r\"$$QFT^\\dagger$$\"\n",
     "qft_inv_circ = Circuit(4)\n",
     "qft_inv_circ.add_gate(inv_qft4_box, [0, 1, 2, 3])\n",
     "draw(qft_inv_circ)"
@@ -249,6 +249,7 @@
    "outputs": [],
    "source": [
     "from pytket.circuit import QControlBox, DiagonalBox\n",
+    "\n",
     "\n",
     "def build_phase_estimation_circuit(\n",
     "    n_measurement_qubits: int, state_prep: CircBox, unitary: CircBox | DiagonalBox\n",
@@ -319,7 +320,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -338,14 +339,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "from pytket.circuit import DiagonalBox\n",
     "import numpy as np\n",
     "\n",
-    "u_diagonal = np.array([1, 1, np.e**(1j * np.pi/4), np.e**(1j * np.pi/8)])\n",
+    "u_diagonal = np.array([1, 1, np.e ** (1j * np.pi / 4), np.e ** (1j * np.pi / 8)])\n",
     "d_box = DiagonalBox(u_diagonal)"
    ]
   },
@@ -358,14 +359,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "qpe_circ_trivial = build_phase_estimation_circuit(\n",
-    "    n_measurement_qubits=4,\n",
-    "    state_prep=prep_box, \n",
-    "    unitary=d_box)"
+    "    n_measurement_qubits=4, state_prep=prep_box, unitary=d_box\n",
+    ")"
    ]
   },
   {
@@ -393,7 +393,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -422,7 +422,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -439,12 +439,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "from pytket.backends.backendresult import BackendResult\n",
     "import matplotlib.pyplot as plt\n",
+    "\n",
     "\n",
     "def plot_qpe_results(\n",
     "    sim_result: BackendResult,\n",
@@ -464,7 +465,7 @@
     "\n",
     "    if dark_mode:\n",
     "        plt.style.use(\"dark_background\")\n",
-    "        \n",
+    "\n",
     "    fig = plt.figure()\n",
     "    ax = fig.add_axes((0, 0, 0.4, 0.5))\n",
     "    color_list = [\"orange\"] * (len(x_axis_values))\n",
@@ -516,11 +517,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "from pytket.backends.backendresult import BackendResult\n",
+    "\n",
     "\n",
     "def single_phase_from_backendresult(result: BackendResult) -> float:\n",
     "    # Extract most common measurement outcome\n",
@@ -616,7 +618,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "pytket-docs",
    "language": "python",
    "name": "python3"
   },
@@ -630,7 +632,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.1"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Description

will avoid this warning showing up due to the `\d`

<img width="767" height="277" alt="Screenshot 2026-05-19 at 18 15 00" src="https://github.com/user-attachments/assets/ac3a5cc2-79ab-478e-b059-f79e550bd0f3" />

some autosave formatting too
